### PR TITLE
Fix updating gates on castling move

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1063,8 +1063,6 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   Square to = to_sq(m);
   Piece pc = moved_piece(m);
   Piece captured = type_of(m) == ENPASSANT ? make_piece(them, PAWN) : piece_on(to);
-  Square rfrom;
-
   if (to == from)
   {
       assert(type_of(m) == PROMOTION && sittuyin_promotion());
@@ -1084,7 +1082,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
       assert(type_of(pc) != NO_PIECE_TYPE);
       assert(captured == make_piece(us, ROOK));
 
-      Square rto;
+      Square rfrom, rto;
       do_castling<true>(us, from, to, rfrom, rto);
 
       k ^= Zobrist::psq[captured][rfrom] ^ Zobrist::psq[captured][rto];
@@ -1298,8 +1296,8 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   {
       if (is_ok(from) && (gates(us) & from))
           st->gatesBB[us] ^= from;
-      if (type_of(m) == CASTLING && (gates(us) & rfrom))
-          st->gatesBB[us] ^= rfrom;
+      if (type_of(m) == CASTLING && (gates(us) & to_sq(m)))
+          st->gatesBB[us] ^= to_sq(m);
       if (gates(them) & to)
           st->gatesBB[them] ^= to;
       if (!count_in_hand(us, ALL_PIECES) && !captures_to_hand())

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1063,6 +1063,8 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   Square to = to_sq(m);
   Piece pc = moved_piece(m);
   Piece captured = type_of(m) == ENPASSANT ? make_piece(them, PAWN) : piece_on(to);
+  Square rfrom;
+
   if (to == from)
   {
       assert(type_of(m) == PROMOTION && sittuyin_promotion());
@@ -1082,7 +1084,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
       assert(type_of(pc) != NO_PIECE_TYPE);
       assert(captured == make_piece(us, ROOK));
 
-      Square rfrom, rto;
+      Square rto;
       do_castling<true>(us, from, to, rfrom, rto);
 
       k ^= Zobrist::psq[captured][rfrom] ^ Zobrist::psq[captured][rto];
@@ -1296,8 +1298,8 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   {
       if (is_ok(from) && (gates(us) & from))
           st->gatesBB[us] ^= from;
-      if (type_of(m) == CASTLING)
-          st->gatesBB[us] ^= to;
+      if (type_of(m) == CASTLING && (gates(us) & rfrom))
+          st->gatesBB[us] ^= rfrom;
       if (gates(them) & to)
           st->gatesBB[them] ^= to;
       if (!count_in_hand(us, ALL_PIECES) && !captures_to_hand())


### PR DESCRIPTION
https://github.com/ianfab/Fairy-Stockfish/blob/master/src/position.cpp#L1300 is wrong because when we are doing a castling move gates can't be set on `to` square if it's a standard game.
If it's a Chess960 castling (king takes rook) the gates on `to` square may or may not be set depending on if we have something in hand to gate or not.

On the other side castling rook `from` square have to be cleared in gates.
