### PR TITLE
Scale danger with check count

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -556,7 +556,7 @@ namespace {
                  + 185 * popcount(kingRing[Us] & weak) * (1 + pos.captures_to_hand() + pos.check_counting())
                  + 148 * popcount(unsafeChecks)
                  +  98 * popcount(pos.blockers_for_king(Us))
-                 +  69 * kingAttacksCount[Them] * (2 + 8 * pos.check_counting() + pos.captures_to_hand()) / 2
+                 +  69 * kingAttacksCount[Them] * (2 + (9 - pos.checks_remaining(Them)) * pos.check_counting() + pos.captures_to_hand()) / 2
                  +   3 * kingFlankAttack * kingFlankAttack / 8
                  +       mg_value(mobility[Them] - mobility[Us])
                  - 873 * !(pos.major_pieces(Them) || pos.captures_to_hand() || pos.king_type() == WAZIR) / (1 + pos.check_counting())


### PR DESCRIPTION
I play chess from https://pychess-variants.herokuapp.com I think I find some bug of program this is my games 

[Event "PyChess casual game"]
[Site "https://pychess-variants.herokuapp.com/WCxatxrK"]
[Date "2020.01.24"]
[Round "-"]
[White "AnonymousINPQ"]
[Black "Fairy-Stockfish"]
[Result "1-0"]
[TimeControl "600+1"]
[WhiteElo "1500?"]
[BlackElo "1500?"]
[Variant "Chess"]

1. e4 e5 2. Nf3 Nc6 3. Nc3 Nf6 4. h3 Bc5 5. Ba6 bxa6 6. d3 h6 7. Bd2 O-O 8. O-O d6 9. Qc1 Bd7 10. Ne2 Bb6 11. Ng3 a5 12. Bxh6 gxh6 13. Qxh6 Qe7 14. Ng5 Bg4 15. hxg4 Nd4 16. Nh5 Ne2+ 17. Kh1 Ng3+ 18. fxg3 a4 19. Qg7# 1-0


I think program cleaver but doesn't understand exactly rules that why I can beat program by 19 move. If you include rule in header flie to search.cpp I think program will understand more and protect game better than now. I hope you understand what I mean.

Regard.

Pcst.