### PR TITLE
Updated ffish.js for initial npm version

### DIFF
--- a/src/ffishjs.cpp
+++ b/src/ffishjs.cpp
@@ -206,10 +206,16 @@ private:
   }
 };
 
+// returns the version of the Fairy-Stockfish binary
+std::string info() {
+   return engine_info();
+}
+
 bool Board::sfInitialized = false;
 
 // binding code
 EMSCRIPTEN_BINDINGS(ffish_js) {
+  function("info", &info);
   class_<Board>("Board")
     .constructor<>()
     .constructor<std::string>()

--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -1,15 +1,21 @@
 # ffish.js
 
-**ffish.js** is a high performance JavaScript library which supports all chess variants of _FairyStockfish_.
+A high performance WebAssembly chess variant library based on _Fairy-Stockfish_.
 
 It is built using emscripten/Embind from C++ source code.
 
 * https://emscripten.org/docs/porting/connecting_cpp_and_javascript/embind.html
 
+## Install instructions
+
+```bash
+npm install ffish
+```
+
 ## Build instuctions
 
 ```bash
-cd ../../src
+cd Fairy-Stockfish/src
 ```
 ```bash
 emcc -O3 --bind ffishjs.cpp \
@@ -45,7 +51,7 @@ xboard.cpp \
 Load the API in JavaScript:
 
 ```javascript
-const ffish = require('./ffish.js');
+const ffish = require('ffish');
 ```
 
 Create a new variant board from its default starting position:
@@ -96,3 +102,57 @@ npm install
 ```bash
 node index.js
 ```
+
+## Compile as ES6/ES2015 module
+
+Some environments such as [vue-js](https://vuejs.org/) may require the library to be exported
+  as a ES6/ES2015 module.
+
+```bash
+cd Fairy-Stockfish/src
+```
+```bash
+emcc -O3 --bind \
+-s ENVIRONMENT='web,worker' -s EXPORT_ES6=1 -s MODULARIZE=1 -s USE_ES6_IMPORT_META=0 \
+ffishjs.cpp \
+benchmark.cpp \
+bitbase.cpp \
+bitboard.cpp \
+endgame.cpp \
+evaluate.cpp \
+material.cpp \
+misc.cpp \
+movegen.cpp \
+movepick.cpp \
+parser.cpp \
+partner.cpp \
+pawns.cpp \
+piece.cpp \
+position.cpp \
+psqt.cpp \
+search.cpp \
+thread.cpp \
+timeman.cpp \
+tt.cpp \
+uci.cpp \
+syzygy/tbprobe.cpp \
+ucioption.cpp \
+variant.cpp \
+xboard.cpp \
+-o ../tests/js/ffish.js
+```
+
+Later the module can be imported as follows:
+
+```javascript
+import Module from './ffish.js';
+let ffish = null;
+
+new Module().then(loadedModule => {
+    ffish = loadedModule;
+    console.log(`initialized ${ffish} ${loadedModule}`);
+    }
+});
+
+```
+References: [emscripten/#10114](https://github.com/emscripten-core/emscripten/issues/10114)

--- a/tests/js/package.json
+++ b/tests/js/package.json
@@ -1,22 +1,33 @@
 {
-  "name": "ffish_test",
-  "version": "1.0.0",
-  "description": "Testing server for ffish.js",
-  "main": "index.js",
+  "name": "ffish",
+  "version": "0.1.4",
+  "description": "A high performance WebAssembly chess variant library based on Fairy-Stockfish",
+  "main": "ffish.js",
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "dev": "node index"
   },
-  "author": "Fabian Fichter, Johannes Czech",
+  "author": [
+    {
+      "name": "Fabian Fichter",
+      "url": "https://github.com/ianfab"
+    },
+    {
+      "name": "Johannes Czech",
+      "url": "https://github.com/QueensGambit"
+    }
+  ],
+  "keywords": ["wasm", "library", "chess-variants", "fairy-stockfish"],
   "license": "GPL-3.0",
-  "dependencies": {
+  "homepage": "https://github.com/ianfab/Fairy-Stockfish/tree/master/tests/js#readme",
+  "dependencies": {},
+  "devDependencies": {
+    "chai": "^4.2.0",
     "chess": "^0.4.3",
     "chess.js": "^0.11.0",
     "crazyhouse.js": "0.0.8",
     "express": "^4.17.1",
+    "mocha": "^8.0.1",
     "performance": "^1.4.0"
-  },
-  "devDependencies": {
-    "chai": "^4.2.0",
-    "mocha": "^8.0.1"
   }
 }

--- a/tests/js/test.js
+++ b/tests/js/test.js
@@ -198,3 +198,9 @@ describe('board.isGameOver()', function () {
     chai.expect(board.isGameOver()).to.equal(true);
   });
 });
+
+describe('ffish.info()', function () {
+  it("it returns the version of the Fairy-Stockfish binary", () => {
+    chai.expect(ffish.info()).to.be.a('string');
+  });
+});


### PR DESCRIPTION
Hello @ianfab ,

due to a request by @gbtami who wants to use the [ffish.js library](https://github.com/ianfab/Fairy-Stockfish/tree/master/tests/js) for the [pychess-variants server](https://www.pychess.org/), I created an official [npm-package](https://www.npmjs.com/package/ffish) for it. The library has an unpacked size of 692 kB including the wasm file and 0 dependencies.

Moreover, I updated [package.json](https://github.com/QueensGambit/Fairy-Stockfish/blob/ffish_js/tests/js/package.json) accordingly and added a `ffish.info()` method which returns the version of the _Fairy-Stockfish_ binary.

I discovered that some js frameworks like [vue-js](https://vuejs.org/) require a wasm library to be exported as an [ES2015](https://en.wikipedia.org/wiki/ECMAScript) module ([emscripten/#10114](https://github.com/emscripten-core/emscripten/issues/10114)).
Therefore, I added additional compile instructions to [README.md](https://github.com/QueensGambit/Fairy-Stockfish/tree/ffish_js/tests/js#compile-as-es6es2015-module) to achieve this.
However, I was unsuccessful in loading the ES2015 module in native node.js where ES2015 is still experimantal.

The current version published on npm (0.1.4) is the regular version and uses the regular syntax to load the library.
```javascript
const ffish = require('ffish');
```

Maybe we can make both versions available on npm but this will increase maintenance effort or we find a proper way at exporting the ES2015 version for node.js.
