### PR TITLE
added -DLARGEBOARDS support

### DIFF
--- a/tests/js/package.json
+++ b/tests/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffish",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A high performance WebAssembly chess variant library based on Fairy-Stockfish",
   "main": "ffish.js",
   "scripts": {

--- a/tests/js/test.js
+++ b/tests/js/test.js
@@ -13,6 +13,7 @@ describe('Constructor: no parameter ', function () {
     const board = new ffish.Board();
     chai.expect(board.fen()).to.equal("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
     chai.expect(board.is960()).to.equal(false);
+    board.delete();
   });
 });
 
@@ -21,6 +22,16 @@ describe('Constructor: variant parameter ', function () {
     const board = new ffish.Board("chess");
     chai.expect(board.fen()).to.equal("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
     chai.expect(board.is960()).to.equal(false);
+    board.delete();
+  });
+});
+
+describe('Constructor: variant parameter with large board', function () {
+  it("it creates a large-board object from a given UCI-variant", () => {
+    const board = new ffish.Board("xiangqi");
+    chai.expect(board.fen()).to.equal("rnbakabnr/9/1c5c1/p1p1p1p1p/9/9/P1P1P1P1P/1C5C1/9/RNBAKABNR w - - 0 1");
+    chai.expect(board.is960()).to.equal(false);
+    board.delete();
   });
 });
 
@@ -29,6 +40,7 @@ describe('Constructor: variant parameter + fen ', function () {
     const board = new ffish.Board("crazyhouse", "rnbqkb1r/pp3ppp/5p2/2pp4/8/5N2/PPPP1PPP/RNBQKB1R/Np w KQkq - 0 5");
     chai.expect(board.fen()).to.equal("rnbqkb1r/pp3ppp/5p2/2pp4/8/5N2/PPPP1PPP/RNBQKB1R[Np] w KQkq - 0 5");
     chai.expect(board.is960()).to.equal(false);
+    board.delete();
   });
 });
 
@@ -37,6 +49,7 @@ describe('Constructor: variant parameter + fen + is960', function () {
     const board = new ffish.Board("chess", "rnknb1rq/pp2ppbp/3p2p1/2p5/4PP2/2N1N1P1/PPPP3P/R1K1BBRQ b KQkq - 1 5", true);
     chai.expect(board.fen()).to.equal("rnknb1rq/pp2ppbp/3p2p1/2p5/4PP2/2N1N1P1/PPPP3P/R1K1BBRQ b GAga - 1 5");
     chai.expect(board.is960()).to.equal(true);
+    board.delete();
   });
 });
 
@@ -49,6 +62,7 @@ describe('board.legalMoves()', function () {
         'Q@g3 Q@h3 Q@a4 Q@b4 Q@c4 Q@d4 Q@f4 Q@g4 Q@h4 Q@a5 Q@b5 Q@d5 Q@f5 Q@g5 Q@h5 Q@a6 Q@b6 Q@d6 Q@e6 Q@f6 Q@g6' +
         ' Q@h6 Q@e7 Q@b8 Q@d8 Q@e8 Q@f8 e1d1 e1f1 e1e2';
     chai.expect(board.legalMoves()).to.equal(expectedMoves);
+    board.delete();
   });
 });
 
@@ -61,6 +75,7 @@ describe('board.legalMovesSan()', function () {
         ' Q@d4 Q@f4+ Q@g4 Q@h4 Q@a5 Q@b5 Q@d5+ Q@f5+ Q@g5 Q@h5+ Q@a6 Q@b6 Q@d6 Q@e6+ Q@f6+ Q@g6+ Q@h6 Q@e7+ Q@b8' +
         ' Q@d8 Q@e8+ Q@f8+ Kd1 Kf1 Ke2';
     chai.expect(board.legalMovesSan()).to.equal(expectedMoves);
+    board.delete();
   });
 });
 
@@ -68,6 +83,7 @@ describe('board.numberLegalMoves()', function () {
   it("it returns all legal moves in uci notation as a concatenated string", () => {
     const board = new ffish.Board("crazyhouse", "r1b3nr/pppp1kpp/2n5/2b1p3/4P3/2N5/PPPP1PPP/R1B1K1NR/QPbq w KQ - 0 7");
     chai.expect(board.numberLegalMoves()).to.equal(90);
+    board.delete();
   });
 });
 
@@ -78,6 +94,7 @@ describe('board.push()', function () {
     board.push("e7e5");
     board.push("g1f3");
     chai.expect(board.fen()).to.equal("rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2");
+    board.delete();
   });
 });
 
@@ -88,6 +105,7 @@ describe('board.pushSan()', function () {
     board.pushSan("e5");
     board.pushSan("Nf3");
     chai.expect(board.fen()).to.equal("rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2");
+    board.delete();
   });
 });
 
@@ -103,8 +121,8 @@ describe('board.pop()', function () {
     board.push("f1b5");
     board.pop();
     board.pop();
-
     chai.expect(board.fen()).to.equal("rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2");
+    board.delete();
   });
 });
 
@@ -116,6 +134,7 @@ describe('board.reset()', function () {
     board.pushSan("Nf3");
     board.reset();
     chai.expect(board.fen()).to.equal("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+    board.delete();
   });
 });
 
@@ -125,6 +144,7 @@ describe('board.is960()', function () {
     chai.expect(board.is960()).to.equal(false);
     const board2 = new ffish.Board("chess", "rnknb1rq/pp2ppbp/3p2p1/2p5/4PP2/2N1N1P1/PPPP3P/R1K1BBRQ b KQkq - 1 5", true);
     chai.expect(board2.is960()).to.equal(true);
+    board.delete();
   });
 });
 
@@ -132,6 +152,7 @@ describe('board.fen()', function () {
   it("it returns the current position in fen format", () => {
     let board = new ffish.Board();
     chai.expect(board.fen()).to.equal("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+    board.delete();
   });
 });
 
@@ -140,6 +161,7 @@ describe('board.setFen()', function () {
     let board = new ffish.Board();
     board.setFen("r1bqkbnr/ppp2ppp/2np4/1B6/3NP3/8/PPP2PPP/RNBQK2R b KQkq - 0 5");
     chai.expect(board.fen()).to.equal("r1bqkbnr/ppp2ppp/2np4/1B6/3NP3/8/PPP2PPP/RNBQK2R b KQkq - 0 5");
+    board.delete();
   });
 });
 
@@ -148,6 +170,7 @@ describe('board.sanMove()', function () {
     const board = new ffish.Board();
     const san = board.sanMove("g1f3");
     chai.expect(san).to.equal("Nf3");
+    board.delete();
   });
 });
 
@@ -157,6 +180,7 @@ describe('board.turn()', function () {
     chai.expect(board.turn()).to.equal(true);
     board.push("e2e4");
     chai.expect(board.turn()).to.equal(false);
+    board.delete();
   });
 });
 
@@ -172,6 +196,7 @@ describe('board.halfmoveClock()', function () {
     chai.expect(board.halfmoveClock()).to.equal(2);
     board.push("f3e5");
     chai.expect(board.halfmoveClock()).to.equal(0);
+    board.delete();
   });
 });
 
@@ -186,6 +211,7 @@ describe('board.gamePly()', function () {
     board.push("g8f6");
     board.push("f3e5");
     chai.expect(board.gamePly()).to.equal(5);
+    board.delete();
   });
 });
 
@@ -196,6 +222,7 @@ describe('board.isGameOver()', function () {
     board.setFen("r1bqkb1r/pppp1ppp/2n2n2/4p2Q/2B1P3/8/PPPP1PPP/RNB1K1NR w KQkq - 4 4");
     board.pushSan("Qxf7#");
     chai.expect(board.isGameOver()).to.equal(true);
+    board.delete();
   });
 });
 


### PR DESCRIPTION
Hello, I build ffish.js with large board support for version 0.1.5 on [npm](https://www.npmjs.com/package/ffish/v/0.1.5).

I needed to add the following flags to emcc to achieve this:

```
-s TOTAL_MEMORY=67108864 -s ALLOW_MEMORY_GROWTH=1 \
 -s WASM_MEM_MAX=2147483648 -DLARGEBOARDS -DPRECOMPUTED_MAGICS \
```

Without the memory flags it resulted in an OOM error and without `-DPRECOMPUTED_MAGICS` it resulted in a timeout.
The file [test.js](https://github.com/ianfab/Fairy-Stockfish/pull/176/files#diff-f2e05ad09d88ee9a8211493d42c470ef) also covers a test for a large board, here Xiangqi.
