### PR TITLE
Added functionality to ffish.js (closes #177)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,6 +5,7 @@
 [![Build Status](https://travis-ci.org/ianfab/Fairy-Stockfish.svg?branch=master)](https://travis-ci.org/ianfab/Fairy-Stockfish)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/ianfab/Fairy-Stockfish?branch=master&svg=true)](https://ci.appveyor.com/project/ianfab/Fairy-Stockfish/branch/master)
 [![PyPI version](https://badge.fury.io/py/pyffish.svg)](https://badge.fury.io/py/pyffish)
+[![NPM version](https://img.shields.io/npm/v/ffish.svg?sanitize=true)](https://www.npmjs.com/package/ffish)
 
 Fairy-Stockfish is a chess variant engine derived from [Stockfish](https://github.com/official-stockfish/Stockfish/) designed for the support of fairy chess variants and easy extensibility with more games. It can play various regional, historical, and modern chess variants as well as [games with user-defined rules](https://github.com/ianfab/Fairy-Stockfish/wiki/Variant-configuration). For [compatibility with graphical user interfaces](https://github.com/ianfab/Fairy-Stockfish/wiki/Usage) it supports the UCI, UCCI, USI, and CECP/XBoard protocols.
 

--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -1,67 +1,59 @@
-# ffish.js
+<h2 align="center">ffish.js</h2>
 
-A high performance WebAssembly chess variant library based on _Fairy-Stockfish_.
+<p align="center">
+<a href="https://img.shields.io/badge/-ffish.js-green"><img src="https://img.shields.io/badge/-ffish.js-green" alt="Package"></a>
+<a href="https://npmcharts.com/compare/ffish?minimal=true"><img src="https://img.shields.io/npm/dm/ffish.svg?sanitize=true" alt="Downloads"></a>
+<a href="https://www.npmjs.com/package/ffish"><img src="https://img.shields.io/npm/v/ffish.svg?sanitize=true" alt="Version"></a>
+</p>
 
-It is built using emscripten/Embind from C++ source code.
+<p align="center">
+<a href="https://img.shields.io/badge/-ffish--es6.js-green"><img src="https://img.shields.io/badge/-ffish--es6.js-green" alt="Package-ES6"></a>
+<a href="https://npmcharts.com/compare/ffish-es6?minimal=true"><img src="https://img.shields.io/npm/dm/ffish-es6.svg?sanitize=true" alt="Downloads-ES6"></a>
+<a href="https://www.npmjs.com/package/ffish-es6"><img src="https://img.shields.io/npm/v/ffish-es6.svg?sanitize=true" alt="Version-ES6"></a>
+</p>
 
-* https://emscripten.org/docs/porting/connecting_cpp_and_javascript/embind.html
+
+The package **ffish.js** is a high performance WebAssembly chess variant library based on [_Fairy-Stockfish_](https://github.com/ianfab/Fairy-Stockfish).
+
+It is available as a [standard module](https://www.npmjs.com/package/ffish) and as an [ES6 module](https://www.npmjs.com/package/ffish-es6).
 
 ## Install instructions
+
+### Standard module
 
 ```bash
 npm install ffish
 ```
 
-## Build instuctions
-
+### ES6 module
 ```bash
-cd Fairy-Stockfish/src
+npm install ffish-es6
 ```
-```bash
-emcc -O3 --bind -s TOTAL_MEMORY=67108864 -s ALLOW_MEMORY_GROWTH=1 \
- -s WASM_MEM_MAX=2147483648 -DLARGEBOARDS -DPRECOMPUTED_MAGICS \
-ffishjs.cpp \
-benchmark.cpp \
-bitbase.cpp \
-bitboard.cpp \
-endgame.cpp \
-evaluate.cpp \
-material.cpp \
-misc.cpp \
-movegen.cpp \
-movepick.cpp \
-parser.cpp \
-partner.cpp \
-pawns.cpp \
-piece.cpp \
-position.cpp \
-psqt.cpp \
-search.cpp \
-thread.cpp \
-timeman.cpp \
-tt.cpp \
-uci.cpp \
-syzygy/tbprobe.cpp \
-ucioption.cpp \
-variant.cpp \
-xboard.cpp \
--o ../tests/js/ffish.js
-```
-
-If you want to disable variants with a board greater than 8x8,
- you can remove the flags `-s TOTAL_MEMORY=67108864 -s
-  ALLOW_MEMORY_GROWTH=1 -s WASM_MEM_MAX=2147483648
-   -DLARGEBOARDS` ``-DPRECOMPUTED_MAGICS`.
-
-The pre-compiled wasm binary is built with `-DLARGEBOARDS`.
 
 ## Examples
 
 Load the API in JavaScript:
 
+### Standard module
+
 ```javascript
 const ffish = require('ffish');
 ```
+
+### ES6 module
+
+```javascript
+import Module from 'ffish';
+let ffish = null;
+
+new Module().then(loadedModule => {
+    ffish = loadedModule;
+    console.log(`initialized ${ffish} ${loadedModule}`);
+    }
+});
+```
+
+### Board object
 
 Create a new variant board from its default starting position.
 The even `onRuntimeInitialized` ensures that the wasm file was properly loaded.
@@ -105,21 +97,58 @@ Therefore, you need to call `.delete()` to free the heap memory of an object.
 board.delete();
 ```
 
-## Instructions to run the tests
+
+## Build instuctions
+
+It is built using emscripten/Embind from C++ source code.
+
+* https://emscripten.org/docs/porting/connecting_cpp_and_javascript/embind.html
+
+
+If you want to disable variants with a board greater than 8x8,
+ you can remove the flags `-s TOTAL_MEMORY=67108864 -s
+  ALLOW_MEMORY_GROWTH=1 -s WASM_MEM_MAX=2147483648
+   -DLARGEBOARDS -DPRECOMPUTED_MAGICS`.
+
+The pre-compiled wasm binary is built with `-DLARGEBOARDS`.
+
+### Compile as standard module
+
 ```bash
-npm install
-npm test
+cd Fairy-Stockfish/src
+```
+```bash
+emcc -O3 --bind -s TOTAL_MEMORY=67108864 -s ALLOW_MEMORY_GROWTH=1 \
+ -s WASM_MEM_MAX=2147483648 -DLARGEBOARDS -DPRECOMPUTED_MAGICS \
+ffishjs.cpp \
+benchmark.cpp \
+bitbase.cpp \
+bitboard.cpp \
+endgame.cpp \
+evaluate.cpp \
+material.cpp \
+misc.cpp \
+movegen.cpp \
+movepick.cpp \
+parser.cpp \
+partner.cpp \
+pawns.cpp \
+piece.cpp \
+position.cpp \
+psqt.cpp \
+search.cpp \
+thread.cpp \
+timeman.cpp \
+tt.cpp \
+uci.cpp \
+syzygy/tbprobe.cpp \
+ucioption.cpp \
+variant.cpp \
+xboard.cpp \
+-o ../tests/js/ffish.js
 ```
 
-## Instructions to run the example server
-```bash
-npm install
-```
-```bash
-node index.js
-```
-
-## Compile as ES6/ES2015 module
+### Compile as ES6/ES2015 module
 
 Some environments such as [vue-js](https://vuejs.org/) may require the library to be exported
   as a ES6/ES2015 module.
@@ -160,17 +189,18 @@ xboard.cpp \
 -o ../tests/js/ffish.js
 ```
 
-Later the module can be imported as follows:
+Reference: [emscripten/#10114](https://github.com/emscripten-core/emscripten/issues/10114)
 
-```javascript
-import Module from './ffish.js';
-let ffish = null;
-
-new Module().then(loadedModule => {
-    ffish = loadedModule;
-    console.log(`initialized ${ffish} ${loadedModule}`);
-    }
-});
-
+## Instructions to run the tests
+```bash
+npm install
+npm test
 ```
-References: [emscripten/#10114](https://github.com/emscripten-core/emscripten/issues/10114)
+
+## Instructions to run the example server
+```bash
+npm install
+```
+```bash
+node index.js
+```

--- a/tests/js/package.json
+++ b/tests/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffish",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "A high performance WebAssembly chess variant library based on Fairy-Stockfish",
   "main": "ffish.js",
   "scripts": {
@@ -17,6 +17,10 @@
       "url": "https://github.com/QueensGambit"
     }
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ianfab/Fairy-Stockfish.git"
+  },
   "keywords": ["wasm", "library", "chess-variants", "fairy-stockfish"],
   "license": "GPL-3.0",
   "homepage": "https://github.com/ianfab/Fairy-Stockfish/tree/master/tests/js#readme",

--- a/tests/js/test.js
+++ b/tests/js/test.js
@@ -8,7 +8,7 @@ before(() => {
   });
 });
 
-describe('Constructor: no parameter ', function () {
+describe('Board()', function () {
   it("it creates a chess board from the default position", () => {
     const board = new ffish.Board();
     chai.expect(board.fen()).to.equal("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
@@ -17,7 +17,7 @@ describe('Constructor: no parameter ', function () {
   });
 });
 
-describe('Constructor: variant parameter ', function () {
+describe('Board(uciVariant) ', function () {
   it("it creates a board object from a given UCI-variant", () => {
     const board = new ffish.Board("chess");
     chai.expect(board.fen()).to.equal("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
@@ -26,7 +26,7 @@ describe('Constructor: variant parameter ', function () {
   });
 });
 
-describe('Constructor: variant parameter with large board', function () {
+describe('Board(uciVariant) with large board', function () {
   it("it creates a large-board object from a given UCI-variant", () => {
     const board = new ffish.Board("xiangqi");
     chai.expect(board.fen()).to.equal("rnbakabnr/9/1c5c1/p1p1p1p1p/9/9/P1P1P1P1P/1C5C1/9/RNBAKABNR w - - 0 1");
@@ -35,7 +35,7 @@ describe('Constructor: variant parameter with large board', function () {
   });
 });
 
-describe('Constructor: variant parameter + fen ', function () {
+describe('Board(uciVariant, fen) ', function () {
   it("it creates a board object for a given UCI-variant with a given FEN", () => {
     const board = new ffish.Board("crazyhouse", "rnbqkb1r/pp3ppp/5p2/2pp4/8/5N2/PPPP1PPP/RNBQKB1R/Np w KQkq - 0 5");
     chai.expect(board.fen()).to.equal("rnbqkb1r/pp3ppp/5p2/2pp4/8/5N2/PPPP1PPP/RNBQKB1R[Np] w KQkq - 0 5");
@@ -44,7 +44,7 @@ describe('Constructor: variant parameter + fen ', function () {
   });
 });
 
-describe('Constructor: variant parameter + fen + is960', function () {
+describe('Board(uciVariant, fen, is960)', function () {
   it("it creates a board object for a given UCI-variant with a given FEN and is960 identifier", () => {
     const board = new ffish.Board("chess", "rnknb1rq/pp2ppbp/3p2p1/2p5/4PP2/2N1N1P1/PPPP3P/R1K1BBRQ b KQkq - 1 5", true);
     chai.expect(board.fen()).to.equal("rnknb1rq/pp2ppbp/3p2p1/2p5/4PP2/2N1N1P1/PPPP3P/R1K1BBRQ b GAga - 1 5");
@@ -87,7 +87,7 @@ describe('board.numberLegalMoves()', function () {
   });
 });
 
-describe('board.push()', function () {
+describe('board.push(uciMove)', function () {
   it("it pushes a move in uci notation to the board", () => {
     let board = new ffish.Board();
     board.push("e2e4");
@@ -156,7 +156,7 @@ describe('board.fen()', function () {
   });
 });
 
-describe('board.setFen()', function () {
+describe('board.setFen(fen)', function () {
   it("it sets a custom position via fen", () => {
     let board = new ffish.Board();
     board.setFen("r1bqkbnr/ppp2ppp/2np4/1B6/3NP3/8/PPP2PPP/RNBQK2R b KQkq - 0 5");
@@ -174,12 +174,72 @@ describe('board.sanMove()', function () {
   });
 });
 
+describe('board.sanMove(ffish.Notation)', function () {
+  it("it converts an uci move into san using a given notation", () => {
+    const board = new ffish.Board();
+    chai.expect(board.sanMove("g1f3", ffish.Notation.DEFAULT)).to.equal("Nf3");
+    chai.expect(board.sanMove("g1f3", ffish.Notation.SAN)).to.equal("Nf3");
+    chai.expect(board.sanMove("g1f3", ffish.Notation.LAN)).to.equal("Ng1-f3");
+    chai.expect(board.sanMove("g1f3", ffish.Notation.SHOGI_HOSKING)).to.equal("N36");
+    chai.expect(board.sanMove("g1f3", ffish.Notation.SHOGI_HODGES)).to.equal("N-3f");
+    chai.expect(board.sanMove("g1f3", ffish.Notation.SHOGI_HODGES_NUMBER)).to.equal("N-36");
+    chai.expect(board.sanMove("g1f3", ffish.Notation.JANGGI)).to.equal("N87-66");
+    chai.expect(board.sanMove("g1f3", ffish.Notation.XIANGQI_WXF)).to.equal("N2+3");
+    board.delete();
+  });
+});
+
+describe('board.variationSan(uciMoves)', function () {
+  it("it converts a list of uci moves into san notation. The board will not changed by this method.", () => {
+    let board = new ffish.Board();
+    board.push("e2e4")
+    const sanMoves = board.variationSan("e7e5 g1f3 b8c6 f1c4");
+    chai.expect(sanMoves).to.equal("1...e5 2. Nf3 Nc6 3. Bc4");
+    board.delete();
+  });
+});
+
+describe('board.variationSan(uciMoves, notation)', function () {
+  it("it converts a list of uci moves into san notation given a notation format", () => {
+    let board = new ffish.Board();
+    board.push("e2e4")
+    const sanMoves = board.variationSan("e7e5 g1f3 b8c6 f1c4", ffish.Notation.LAN);
+    chai.expect(sanMoves).to.equal("1...e7-e5 2. Ng1-f3 Nb8-c6 3. Bf1-c4");
+    board.delete();
+  });
+});
+
+describe('board.variationSan(uciMoves, notation, moveNumbers)', function () {
+  it("it converts a list of uci moves into san notation given a notation format and optionally disabling move numbers", () => {
+    let board = new ffish.Board();
+    board.push("e2e4")
+    const sanMoves = board.variationSan("e7e5 g1f3 b8c6 f1c4", ffish.Notation.SAN, false);
+    chai.expect(sanMoves).to.equal("e5 Nf3 Nc6 Bc4");
+    board.delete();
+  });
+});
+
 describe('board.turn()', function () {
   it("it returns the side to move", () => {
     let board = new ffish.Board();
     chai.expect(board.turn()).to.equal(true);
     board.push("e2e4");
     chai.expect(board.turn()).to.equal(false);
+    board.delete();
+  });
+});
+
+describe('board.fullmoveNumber()', function () {
+  it("it returns the move number starting with 1 and is increment after each move of the 2nd player", () => {
+    let board = new ffish.Board();
+    chai.expect(board.fullmoveNumber()).to.equal(1);
+    board.push("e2e4");
+    chai.expect(board.fullmoveNumber()).to.equal(1);
+    board.push("e7e5");
+    board.push("g1f3");
+    board.push("g8f6");
+    board.push("f3e5");
+    chai.expect(board.fullmoveNumber()).to.equal(3);
     board.delete();
   });
 });
@@ -226,8 +286,52 @@ describe('board.isGameOver()', function () {
   });
 });
 
+describe('board.isCheck()', function () {
+  it("it checks if a player is in check", () => {
+    let board = new ffish.Board();
+    chai.expect(board.isCheck()).to.equal(false);
+    board.setFen("rnbqkb1r/pppp1Bpp/5n2/4p3/4P3/8/PPPP1PPP/RNBQK1NR b KQkq - 0 3");
+    chai.expect(board.isCheck()).to.equal(true);
+    board.setFen("r1bqkb1r/pppp1ppp/2n2n2/4p2Q/2B1P3/8/PPPP1PPP/RNB1K1NR w KQkq - 4 4");
+    board.pushSan("Qxf7#");
+    chai.expect(board.isCheck()).to.equal(true);
+    board.delete();
+  });
+});
+
+describe('board.isBikjang()', function () {
+  it("it checks if a player is in bikjang (only relevant for janggi)", () => {
+    let board = new ffish.Board("janggi");
+    chai.expect(board.isBikjang()).to.equal(false);
+    board.setFen("rnba1abnr/4k4/1c5c1/p1p3p1p/9/9/P1P3P1P/1C5C1/4K4/RNBA1ABNR w - - 0 1");
+    chai.expect(board.isBikjang()).to.equal(true);
+    board.delete();
+  });
+});
+
 describe('ffish.info()', function () {
   it("it returns the version of the Fairy-Stockfish binary", () => {
     chai.expect(ffish.info()).to.be.a('string');
+  });
+});
+
+describe('ffish.setOption(name, value)', function () {
+  it("it sets a string uci option value pair", () => {
+    ffish.setOption("VariantPath", "variants.ini");
+    chai.expect(true).to.equal(true);
+  });
+});
+
+describe('ffish.setOptionInt(name, value)', function () {
+  it("it sets a int uci option value pair", () => {
+    ffish.setOptionInt("Threads", 4);
+    chai.expect(true).to.equal(true);
+  });
+});
+
+describe('ffish.setOptionBool(name, value)', function () {
+  it("it sets a boolean uci option value pair", () => {
+    ffish.setOptionBool("Ponder", true);
+    chai.expect(true).to.equal(true);
   });
 });


### PR DESCRIPTION
Hello @ianfab  and @gbtami ,

I added the requested functionality from #177 resulting in **ffish.js v0.2.0**.

- [x] setoption(name, value) to set variants.ini path
Is now available as a static method. Because you can only overload methods based on the number of arguments from emscripten and not based on variable type, I exported additional methods for integer and boolean options.
However, loading files from JavaScript is tricky and unavailable for browsers.
It seems you require the [filesystem-API](https://emscripten.org/docs/api_reference/Filesystem-API.html#including-file-system-support) for that because I receive: `Unable to open file variants.ini` when setting the `VariantPath`.
Perhaps it is better to add an additional method just for parsing a `variant.ini`-string without reading the file within the library.
  - ffish.setOption()
  - ffish.setOptionInt()
  - ffish.setOptionBool()

- [x] Board.isCheck() to style king in check
  - board.isCheck()

- [x] Board.isBikjang() to style kings in bikjang
  - board.isBikjang()

- [x] Board.movesToSan(movelist, notation) to convert analysis PV to SAN movelist
I chose the name `variationSan()` instead, same as in [python-chess](https://python-chess.readthedocs.io/en/latest/core.html#chess.Board.variation_san) for consistency.
However, it has an additional optional parameter `moveNumbers` which allows to disable move numbers.
  - board.variationSan(uciMoves)
  - board.variationSan(uciMoves, notation)
  - board.variationSan(uciMoves, notation, moveNumbers)
- [x] Board.san_move() should accept notation parameter also (now NOTATION_SAN is hardwired)
I exported the enum Notation which can now be used as an optional parameter.
  - board.sanMove(notation)
  - enum ffish.Notation

- [x] ES6 module export
  - I published [ffish-es6](https://www.npmjs.com/package/ffish-es6) as a separate module to npm. Moreover, I added badges to [README.md](https://github.com/ianfab/Fairy-Stockfish/blob/master/tests/js/README.md) to track how often each package is downloaded and to see which one is more popular.

### Additional method(s)

- [x] board.fullmoveNumber()
  Returns the full move counter starting at 1.


