### PR TITLE
Increase midgame value of aiwok

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -341,7 +341,7 @@ enum Value : int {
   AlfilValueMg             = 350,   AlfilValueEg             = 330,
   FersAlfilValueMg         = 700,   FersAlfilValueEg         = 650,
   SilverValueMg            = 630,   SilverValueEg            = 630,
-  AiwokValueMg             = 2300,  AiwokValueEg             = 2700,
+  AiwokValueMg             = 2400,  AiwokValueEg             = 2700,
   BersValueMg              = 1900,  BersValueEg              = 2000,
   ArchbishopValueMg        = 2200,  ArchbishopValueEg        = 2200,
   ChancellorValueMg        = 2300,  ChancellorValueEg        = 2600,


### PR DESCRIPTION
Since aiwok = chancellor + fers, the aiwok’s value should be greater than that of the chancellor.