### PR TITLE
Support atomic chess without checks (#81)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The games currently supported besides chess are listed below. Fairy-Stockfish ca
 - [King of the Hill](https://en.wikipedia.org/wiki/King_of_the_Hill_(chess)), [Racing Kings](https://en.wikipedia.org/wiki/V._R._Parton#Racing_Kings)
 - [Three-check](https://en.wikipedia.org/wiki/Three-check_chess), Five-check
 - [Los Alamos](https://en.wikipedia.org/wiki/Los_Alamos_chess)
+- [Atomic](https://en.wikipedia.org/wiki/Atomic_chess) (non-standard rules)
 - [Horde](https://en.wikipedia.org/wiki/Dunsany%27s_Chess#Horde_Chess)
 - [Knightmate](https://www.chessvariants.com/diffobjective.dir/knightmate.html)
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -237,6 +237,7 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
     parse_attribute("mandatoryPawnPromotion", v->mandatoryPawnPromotion);
     parse_attribute("mandatoryPiecePromotion", v->mandatoryPiecePromotion);
     parse_attribute("pieceDemotion", v->pieceDemotion);
+    parse_attribute("blastOnCapture", v->blastOnCapture);
     parse_attribute("endgameEval", v->endgameEval);
     parse_attribute("doubleStep", v->doubleStep);
     parse_attribute("doubleStepRank", v->doubleStepRank);
@@ -365,6 +366,18 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
                     std::cerr << "pieceToCharTable - Missing piece type: " << ptu << std::endl;
             }
         }
+
+        // Check for limitations
+
+        // Options incompatible with royal kings
+        if (v->pieceTypes.find(KING) != v->pieceTypes.end())
+        {
+            if (v->blastOnCapture)
+                std::cerr << "Can not use kings with blastOnCapture" << std::endl;
+            if (v->flipEnclosedPieces)
+                std::cerr << "Can not use kings with flipEnclosedPieces" << std::endl;
+        }
+
     }
     return v;
 }

--- a/src/position.h
+++ b/src/position.h
@@ -58,6 +58,9 @@ struct StateInfo {
   Bitboard   checkersBB;
   Piece      capturedPiece;
   Piece      unpromotedCapturedPiece;
+  Piece      unpromotedBycatch[SQUARE_NB];
+  Bitboard   promotedBycatch;
+  Bitboard   demotedBycatch;
   StateInfo* previous;
   Bitboard   blockersForKing[COLOR_NB];
   Bitboard   pinners[COLOR_NB];
@@ -122,6 +125,7 @@ public:
   bool mandatory_pawn_promotion() const;
   bool mandatory_piece_promotion() const;
   bool piece_demotion() const;
+  bool blast_on_capture() const;
   bool endgame_eval() const;
   bool double_step_enabled() const;
   Rank double_step_rank_max() const;
@@ -251,6 +255,7 @@ public:
   void undo_null_move();
 
   // Static Exchange Evaluation
+  Value blast_see(Move m) const;
   bool see_ge(Move m, Value threshold = VALUE_ZERO) const;
 
   // Accessing hash keys
@@ -420,6 +425,11 @@ inline bool Position::mandatory_piece_promotion() const {
 inline bool Position::piece_demotion() const {
   assert(var != nullptr);
   return var->pieceDemotion;
+}
+
+inline bool Position::blast_on_capture() const {
+  assert(var != nullptr);
+  return var->blastOnCapture;
 }
 
 inline bool Position::endgame_eval() const {

--- a/src/psqt.cpp
+++ b/src/psqt.cpp
@@ -129,7 +129,11 @@ void init(const Variant* v) {
 
       // Consider promotion types in pawn score
       if (pt == PAWN)
+      {
           score -= make_score(0, (QueenValueEg - maxPromotion) / 100);
+          if (v->blastOnCapture)
+              score += score;
+      }
 
       // Scale slider piece values with board size
       const PieceInfo* pi = pieceMap.find(pt)->second;
@@ -166,6 +170,9 @@ void init(const Variant* v) {
           score = make_score(mg_value(score) * 2000 / (3500 + mg_value(score)),
                              eg_value(score) * 2200 / (3500 + eg_value(score)));
       else if (v->twoBoards)
+          score = make_score(mg_value(score) * 7000 / (7000 + mg_value(score)),
+                             eg_value(score) * 7000 / (7000 + eg_value(score)));
+      else if (v->blastOnCapture)
           score = make_score(mg_value(score) * 7000 / (7000 + mg_value(score)),
                              eg_value(score) * 7000 / (7000 + eg_value(score)));
       else if (v->checkCounting)

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -45,7 +45,7 @@ namespace UCI {
 // standard variants of XBoard/WinBoard
 std::set<string> standard_variants = {
     "normal", "nocastle", "fischerandom", "knightmate", "3check", "makruk", "shatranj",
-    "asean", "seirawan", "crazyhouse", "bughouse", "suicide", "giveaway", "losers",
+    "asean", "seirawan", "crazyhouse", "bughouse", "suicide", "giveaway", "losers", "atomic",
     "capablanca", "gothic", "janus", "caparandom", "grand", "shogi", "xiangqi"
 };
 

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -289,6 +289,26 @@ namespace {
         v->extinctionPieceTypes = {ALL_PIECES};
         return v;
     }
+    // Atomic chess without checks (ICC rules)
+    // https://www.chessclub.com/help/atomic
+    Variant* nocheckatomic_variant() {
+        Variant* v = fairy_variant_base();
+        v->variantTemplate = "atomic";
+        v->remove_piece(KING);
+        v->add_piece(COMMONER, 'k');
+        v->extinctionValue = -VALUE_MATE;
+        v->extinctionPieceTypes = {COMMONER};
+        v->blastOnCapture = true;
+        return v;
+    }
+    // Atomic chess
+    // https://en.wikipedia.org/wiki/Atomic_chess
+    Variant* atomic_variant() {
+        Variant* v = nocheckatomic_variant();
+        // TODO: castling, check(-mate), stalemate are not yet properly implemented
+        v->extinctionPseudoRoyal = true;
+        return v;
+    }
     Variant* threecheck_variant() {
         Variant* v = fairy_variant_base();
         v->startFen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 3+3 0 1";
@@ -998,6 +1018,8 @@ void VariantMap::init() {
     add("kinglet", kinglet_variant()->conclude());
     add("threekings", threekings_variant()->conclude());
     add("horde", horde_variant()->conclude());
+    add("nocheckatomic", nocheckatomic_variant()->conclude());
+    add("atomic", atomic_variant()->conclude());
     add("3check", threecheck_variant()->conclude());
     add("5check", fivecheck_variant()->conclude());
     add("crazyhouse", crazyhouse_variant()->conclude());

--- a/src/variant.h
+++ b/src/variant.h
@@ -54,6 +54,7 @@ struct Variant {
   bool mandatoryPawnPromotion = true;
   bool mandatoryPiecePromotion = false;
   bool pieceDemotion = false;
+  bool blastOnCapture = false;
   bool endgameEval = false;
   bool doubleStep = true;
   Rank doubleStepRank = RANK_2;
@@ -112,6 +113,7 @@ struct Variant {
   bool bikjangRule = false;
   Value extinctionValue = VALUE_NONE;
   bool extinctionClaim = false;
+  bool extinctionPseudoRoyal = false; // TODO: implementation incomplete
   std::set<PieceType> extinctionPieceTypes = {};
   int extinctionPieceCount = 0;
   int extinctionOpponentPieceCount = 0;

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -119,6 +119,7 @@
 # mandatoryPawnPromotion: pawn promotion is mandatory [bool] (default: true)
 # mandatoryPiecePromotion: piece promotion (and demotion if enabled) is mandatory [bool] (default: false)
 # pieceDemotion: enable demotion of pieces (e.g., Kyoto shogi) [bool] (default: false)
+# blastOnCapture: captures explode all adjacent non-pawn pieces (e.g., atomic chess) [bool] (default: false)
 # endgameEval: enable special endgame evaluation (for very chess-like variants only) [bool] (default: false)
 # doubleStep: enable pawn double step [bool] (default: true)
 # doubleStepRank: relative rank from where pawn double steps are allowed [Rank] (default: 2)


### PR DESCRIPTION
Add variant nocheckatomic which implements a modified version
of atomic chess where check and check-/stalemate do not apply,
which is very similar to the rules used on ICC.

The variant atomic is an incomplete implementation of
lichess atomic chess rules, added for easier usage in GUIs.
It will occasionally play illegal moves in this variant.