### PR TITLE
Updated ffish.js to 0.6.0, fixes ffish.validateFen(), ffish.readGamePGN(pgn), added board.variant(), atomic support

### DIFF
--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -61,13 +61,18 @@ Show all available variants supported by _Fairy-Stockfish_ and **ffish.js**.
 ffish.variants()
 ```
 ```
-3check 5check ai-wok almost amazon antichess armageddon asean ataxx breakthrough bughouse cambodian\
-capablanca capahouse caparandom centaur chancellor chess chessgi chigorin clobber clobber10 codrus courier\
-crazyhouse dobutsu embassy euroshogi extinction fairy fischerandom gardner giveaway gorogoro gothic grand\
-hoppelpoppel horde janggi janggicasual janggimodern janggitraditional janus jesonmor judkins karouk kinglet\
-kingofthehill knightmate koedem kyotoshogi loop losalamos losers makpong makruk manchu micro mini minishogi\
-minixiangqi modern newzealand nocastle normal placement pocketknight racingkings seirawan shako shatar\
-shatranj shogi shouse sittuyin suicide supply threekings xiangqi
+3check 3check-crazyhouse 5check ai-wok almost amazon anti-losalamos antichess\
+armageddon asean ataxx atomic breakthrough bughouse cambodian capablanca\
+capahouse caparandom centaur cfour chancellor chaturanga chess chessgi chigorin\
+clobber clobber10 codrus coffeehouse courier crazyhouse dobutsu embassy euroshogi\
+extinction fairy fischerandom flipello flipersi gardner gemini giveaway gorogoro\
+gothic grand grandhouse hoppelpoppel horde indiangreat janggi janggicasual\
+janggihouse janggimodern janggitraditional janus jesonmor judkins karouk kinglet\
+kingofthehill knightmate koedem kyotoshogi loop losalamos losers makpong makruk\
+makrukhouse manchu micro mini minishogi minixiangqi modern newzealand nocastle\
+nocheckatomic normal orda pawnsonly peasant placement pocketknight racingkings\
+seirawan semitorpedo shako shatar shatranj shogi shogun shouse sittuyin suicide\
+supply threekings tictactoe upsidedown weak xiangqi xiangqihouse
 ```
 
 ### Board object
@@ -81,10 +86,10 @@ ffish['onRuntimeInitialized'] = () => {
 }
 ```
 
-Set a custom fen position including fen valdiation:
+Set a custom fen position including fen validiation:
 ```javascript
 fen = "rnb1kbnr/ppp1pppp/8/3q4/8/8/PPPP1PPP/RNBQKBNR w KQkq - 0 3";
-if (ffish.valdiateFen(fen) == 1) {  // ffish.valdiateFen(fen) can return different error codes, it returns 1 for FEN_OK
+if (ffish.validateFen(fen) == 1) {  // ffish.validateFen(fen) can return different error codes, it returns 1 for FEN_OK
     board.setFen(fen);
 }
 else {

--- a/tests/js/package.json
+++ b/tests/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffish",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "A high performance WebAssembly chess variant library based on Fairy-Stockfish",
   "main": "ffish.js",
   "scripts": {


### PR DESCRIPTION
Hi @ianfab ,

I noticed that you integrated atomic into Fairy-Stockfish (https://github.com/ianfab/Fairy-Stockfish/pull/238 ).
Many people will enjoy using it in **ffish.js@0.6.0**, too.

## Bug fixes
* **ffish.readGamePGN(pgn)** sometimes pushed  `{` as SanMoves. This is now fixed by incrementing `curIdx`.
*  **ffish.validateFen()** is more robust now and allows the placeholder `-` for variants which do not have a no-progress counter or castling rights. The unit tests have been extended accordingly to also check the fen after a board object has been created using the starting-fen.

## New features

* **board.variant()** it returns the uci-variant of the board.

## Miscellaneous

* **board.push()**, **board.pushSan()**, **board.sanMove()**, **board.variationSan()** now inform the user via _stderr_ if a given move is invalid and will return **false** or **""**. I noticed that `UCI::to_move(const Position& pos, string& str)` already does a legal move check. Therefore, this additional runtime overhead is very small.