### PR TITLE
Support pseudo-royal pieces

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -298,6 +298,7 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
     parse_attribute("bikjangRule", v->bikjangRule);
     parse_attribute("extinctionValue", v->extinctionValue);
     parse_attribute("extinctionClaim", v->extinctionClaim);
+    parse_attribute("extinctionPseudoRoyal", v->extinctionPseudoRoyal);
     // extinction piece types
     const auto& it_ext = config.find("extinctionPieceTypes");
     if (it_ext != config.end())

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -310,7 +310,6 @@ namespace {
     // https://en.wikipedia.org/wiki/Atomic_chess
     Variant* atomic_variant() {
         Variant* v = nocheckatomic_variant();
-        // TODO: castling, check(-mate), stalemate are not yet properly implemented
         v->extinctionPseudoRoyal = true;
         return v;
     }
@@ -613,6 +612,14 @@ namespace {
         v->extinctionPieceTypes = {ALL_PIECES};
         v->extinctionPieceCount = 1;
         v->shatarMateRule = true;
+        return v;
+    }
+    Variant* coregal_variant() {
+        Variant* v = fairy_variant();
+        v->extinctionValue = -VALUE_MATE;
+        v->extinctionPieceTypes = {QUEEN};
+        v->extinctionPseudoRoyal = true;
+        v->extinctionPieceCount = 64; // no matter how many queens, all are royal
         return v;
     }
     Variant* clobber_variant() {
@@ -1051,6 +1058,7 @@ void VariantMap::init() {
     add("almost", almost_variant()->conclude());
     add("chigorin", chigorin_variant()->conclude());
     add("shatar", shatar_variant()->conclude());
+    add("coregal", coregal_variant()->conclude());
     add("clobber", clobber_variant()->conclude());
     add("breakthrough", breakthrough_variant()->conclude());
     add("ataxx", ataxx_variant()->conclude());

--- a/src/variant.h
+++ b/src/variant.h
@@ -115,7 +115,7 @@ struct Variant {
   bool bikjangRule = false;
   Value extinctionValue = VALUE_NONE;
   bool extinctionClaim = false;
-  bool extinctionPseudoRoyal = false; // TODO: implementation incomplete
+  bool extinctionPseudoRoyal = false;
   std::set<PieceType> extinctionPieceTypes = {};
   int extinctionPieceCount = 0;
   int extinctionOpponentPieceCount = 0;

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -179,6 +179,7 @@
 # bikjangRule: consider Janggi bikjang (facing kings) rule [bool] (default: false)
 # extinctionValue: result when one of extinctionPieceTypes is extinct [Value] (default: none)
 # extinctionClaim: extinction of opponent pieces can only be claimed as side to move [bool] (default: false)
+# extinctionPseudoRoyal: treat the last extinction piece like a royal piece [bool] (default: false)
 # extinctionPieceTypes: list of piece types for extinction rules, e.g., pnbrq (* means all) (default: )
 # extinctionPieceCount: piece count at which the game is decided by extinction rule (default: 0)
 # extinctionOpponentPieceCount: opponent piece count required to adjudicate by extinction rule (default: 0)
@@ -295,6 +296,22 @@ promotionRank = 10
 promotionPieceTypes = q
 doubleStep = false
 castling = false
+
+# Mahajarah and the Sepoys
+# https://en.wikipedia.org/wiki/Maharajah_and_the_Sepoys
+[maharajah]
+pawn = p
+knight = n
+bishop = b
+rook = r
+queen = q
+king = k
+amazon = m
+pieceToCharTable = PNBRQ.............MKpnbrq.............mk
+startFen = rnbqkbnr/pppppppp/8/8/8/8/8/4M3 w kq - 0 1
+extinctionValue = loss
+extinctionPieceTypes = m
+extinctionPseudoRoyal = true
 
 # Upside-down
 [upsidedown:chess]

--- a/tests/perft.sh
+++ b/tests/perft.sh
@@ -47,6 +47,13 @@ if [[ $1 == "" || $1 == "variant" ]]; then
   expect perft.exp racingkings startpos 4 296242 > /dev/null
   expect perft.exp racingkings "fen 6r1/2K5/5k2/8/3R4/8/8/8 w - - 0 1" 4 86041 > /dev/null
   expect perft.exp racingkings "fen 6R1/2k5/5K2/8/3r4/8/8/8 b - - 0 1" 4 86009 > /dev/null
+  expect perft.exp atomic startpos 4 197326 > /dev/null
+  expect perft.exp atomic "fen rn2kb1r/1pp1p2p/p2q1pp1/3P4/2P3b1/4PN2/PP3PPP/R2QKB1R b KQkq - 0 1" 4 1434825 > /dev/null
+  expect perft.exp atomic "fen rn1qkb1r/p5pp/2p5/3p4/N3P3/5P2/PPP4P/R1BQK3 w Qkq - 0 1" 4 714499 > /dev/null
+  expect perft.exp coregal startpos 4 195896 > /dev/null
+  expect perft.exp coregal "fen rn2kb1r/ppp1pppp/6q1/8/2PP2b1/5B2/PP3P1P/R1BQK1NR w KQkq - 1 9" 3 20421 > /dev/null
+  expect perft.exp coregal "fen 2Q5/3Pq2k/6p1/4Bp1p/5P1P/8/8/K7 w - - 2 72" 4 55970 > /dev/null
+  expect perft.exp coregal "fen r3kb1r/1pp1pppp/p1q2n2/3P4/6b1/2N2N2/PPP2PPP/R1BQ1RK1 b kq - 0 9" 4 136511 > /dev/null
   expect perft.exp knightmate startpos 5 3249033 > /dev/null
   expect perft.exp losers startpos 5 2723795 > /dev/null
   expect perft.exp antichess startpos 5 2732672 > /dev/null


### PR DESCRIPTION
This implements support for pseudo-royal pieces,
which allows to now fully support some new variants:
- lichess atomic rules
- coregal chess
- maharajah and the sepoys

Closes #81.

No functional change for other variants.