### PR TITLE
Update Variants.ini

### DIFF
--- a/src/variants.ini
+++ b/src/variants.ini
@@ -560,7 +560,7 @@ startFen = rnbqk/ppppp/5/5/PPPPP/RNBQK w - - 0 1
 # https://greenchess.net/rules.php?v=active
 [active:chess]
 maxFile = i
-startFen = rnbkqbnrq/ppppppppp/9/9/9/9/PPPPPPPPP/RNBKQBNRQ w KQkq 0 1
+startFen = rnbkqbnrq/ppppppppp/9/9/9/9/PPPPPPPPP/RNBKQBNRQ w KQkq - 0 1
 
 # Checkless 6x6 Atomic
 [6x6atom:nocheckatomic]
@@ -592,6 +592,8 @@ startFen = r6r/1nbqkbn1/pppppppp/8/8/PPPPPPPP/1NBQKBN1/R6R w - - 0 1
 # Diana Chess // Kingside castling not working!
 # https://greenchess.net/rules.php?v=diana
 [diana:losalamos]
+pieceToCharTable = PNBRQ................Kpnbrq................k
+bishop = b
 promotionPieceTypes = rbn
 castling = true
 castlingKingsideFile = e
@@ -649,3 +651,33 @@ immobilityIllegal = true
 flagPiece = k
 whiteFlag = *8
 blackFlag = *1
+
+# Wildebeest
+# https://vchess.club/#/variants/Wildebeest (switching flexible castling with no-castling)
+[wildebeest:chess]
+castling = false
+maxRank = 10
+maxFile = k
+customPiece5 = c:C
+customPiece6 = w:NC
+pieceToCharTable = PNBRQ.......C....WKpnbrq.......c....wk
+startFen = rnccwkqbbnr/ppppppppppp/11/11/11/11/11/11/PPPPPPPPPPP/RNBBQKWCCNR w KQkq - 0 1
+promotionPieceTypes = qw
+promotionRank = 9
+mandatoryPawnPromotion = false
+
+# Maharajah
+# https://vchess.club/#/variants/Maharajah (Balanced version of Maharajah and the Sepoys)
+[maharajah2]
+pawn = p
+knight = n
+bishop = b
+rook = r
+queen = q
+king = k
+customPiece7 = m:QNAD
+pieceToCharTable = PNBRQ.............MKpnbrq.............mk
+startFen = 3mm3/8/8/8/8/8/PPPPPPPP/RNBQKBNR w KQ - 0 1
+extinctionValue = loss
+extinctionPieceTypes = m
+extinctionPseudoRoyal = true

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -67,11 +67,14 @@
 # shogiPawn
 # lance
 # shogiKnight
+# euroshogiKnight
 # gold
 # dragonHorse
 # clobber
 # breakthrough
 # immobile (piece without moves)
+# ataxx (mDNA)
+# quietQueen
 # cannon
 # janggiCannon
 # soldier
@@ -83,32 +86,6 @@
 # commoner (non-royal king)
 # centaur (=knight+commoner)
 # king
-
-### Custom pieces
-# Custom pieces can be defined by using one of the available slots:
-# customPiece1, customPiece2, ..., customPiece26
-# E.g., pawns without double steps could be described as:
-# customPiece1 = p:mfWcfF
-#
-# The movements of custom pieces can be defined using the Betza notation.
-# https://www.gnu.org/software/xboard/Betza.html
-# In Fairy-Stockfish only a subset of Betza notation can be used. The supported features are:
-# - all base moves/atoms (W, F, etc.)
-# - all directional modifiers (f, b, etc.)
-# - unlimited distance sliders for W/R and F/B directions
-# - hoppers for W/R directions, i.e., pR
-# - lame leapers (n) for N and A directions, i.e., nN and nA
-
-### Piece values
-# The predefined and precalculated piece values can be overriden
-# by specifying the pieceValueMg and pieceValueEg options, e.g.,
-# pieceValueMg = p:150 n:800
-# pieceValueEg = p:200 n:900
-#
-# For orientation, the internal predefined piece values can be found in types.h.
-# A suitable piece for gauging the piece values is the rook, which internally has:
-# pieceValueMg = r:1276
-# pieceValueEg = r:1380
 
 ### Option types
 # [bool]: boolean flag to enable/disable a feature [true, false]
@@ -122,16 +99,10 @@
 # [CountingRule]: makruk or ASEAN counting rules [makruk, asean, none]
 # [EnclosingRule]: reversi or ataxx enclosing rules [reversi, ataxx, none]
 
-### Additional options relevant for usage in Winboard/XBoard
-# A few options only have the purpose of improving compatibility with Winboard/Xboard.
-# These do not need to be specified when using other GUIs, but can be essential for Winboard/Xboard.
-#
-# variantTemplate: base variant to inherit GUI logic from [values: fairy, shogi, bughouse] (default: fairy)
-# pieceToCharTable: mapping of piece characters to images,
-#                   see https://www.gnu.org/software/xboard/whats_new/4.9.0/index.html#tag-B1 (default: -)
-# pocketSize: number of pockets shown by XBoard/WinBoard for drop variants [int] (default: 0)
-
 ### Rule definition options
+# variantTemplate: only relevant for usage in XBoard/WinBoard GUI [values: fairy, shogi] (default: fairy)
+# pieceToCharTable: mapping of piece characters to images for XBoard/WinBoard GUI (default: -)
+# pocketSize: number of pockets shown by XBoard/WinBoard for drop variants [int] (default: 0)
 # maxRank: maximum rank [Rank] (default: 8)
 # maxFile: maximum file [File] (default: 8)
 # chess960: allow chess960 castling [bool] (default: false)
@@ -149,6 +120,7 @@
 # mandatoryPiecePromotion: piece promotion (and demotion if enabled) is mandatory [bool] (default: false)
 # pieceDemotion: enable demotion of pieces (e.g., Kyoto shogi) [bool] (default: false)
 # blastOnCapture: captures explode all adjacent non-pawn pieces (e.g., atomic chess) [bool] (default: false)
+# endgameEval: enable special endgame evaluation (for very chess-like variants only) [bool] (default: false)
 # doubleStep: enable pawn double step [bool] (default: true)
 # doubleStepRank: relative rank from where pawn double steps are allowed [Rank] (default: 2)
 # doubleStepRankMin: earlist relative rank from where pawn double steps are allowed [Rank] (default: 2)
@@ -449,7 +421,8 @@ whiteDropRegion = *1 *2 *3 *4 *5
 blackDropRegion = *4 *5 *6 *7 *8
 immobilityIllegal = true
 
-# Asymmetric variant with one army using pieces that move like knights but attack like other pieces (kniroo and knibis)
+# Orda: Asymmetric variant with one army using pieces that move like knights but attack like other pieces (kniroo and knibis)
+# https://www.pychess.org/variant/orda
 [orda:chess]
 pieceToCharTable = PNBRQ..AH...........LKp...q..ah.y.........lk
 centaur = h
@@ -462,16 +435,162 @@ flagPiece = k
 whiteFlag = *8
 blackFlag = *1
 
-# Ordamirror
-# https://vchess.club/#/variants/Ordamirror
-[ordamirror:chess]
-pieceToCharTable = P...Q..AH.F.........LKp...q..ah.f.........lk
-centaur = h
-knibis = a
-kniroo = l
-customPiece1 = f:mQcN
-promotionPieceTypes = qh
-startFen = lhafkahl/8/pppppppp/8/8/PPPPPPPP/8/LHAFKAHL w - - 0 1
+# Hybrid variant of Gothic-chess and crazyhouse, using Capablanca as a template
+[gothhouse:capablanca]
+startFen = rnbqckabnr/pppppppppp/10/10/10/10/PPPPPPPPPP/RNBQCKABNR[] w KQkq - 0 1
+pieceDrops = true
+capturesToHand = true
+
+# Synochess
+# https://www.pychess.org/variant/synochess
+[synochess:pocketknight]
+pieceToCharTable = PNBRQAE...SCH........Kpnbrqae...sch........k
+pocketSize = 8
+janggiCannon = c
+soldier = s
+horse = h
+fersAlfil = e
+commoner = a
+stalemateValue = loss
+perpetualCheckIllegal = true
+startFen = rneakenr/8/1c4c1/1ss2ss1/8/8/PPPPPPPP/RNBQKBNR[ss] w KQ - 0 1
+flyingGeneral = true
+capturesToHand = false
+blackDropRegion = *5
 flagPiece = k
 whiteFlag = *8
 blackFlag = *1
+
+# Capture chess
+# https://vchess.club/#/variants/Capture
+[capture:chess]
+mustCapture = true
+
+# Ordamirror
+# https://vchess.club/#/variants/Ordamirror
+[ordamirror:chess]
+pieceToCharTable = P...Q..AH.Y.........LKp...q..ah.y.........lk
+centaur = h
+knibis = a
+kniroo = l
+silver = y
+promotionPieceTypes = qh
+startFen = lhaykahl/8/pppppppp/8/8/PPPPPPPP/8/LHAYKAHL w - 0 1
+flagPiece = k
+whiteFlag = *8
+blackFlag = *1
+
+# Perfect chess
+# https://vchess.club/#/variants/Perfect
+[perfect:amazon]
+pieceToCharTable = PNBRQ........S..C.A...Kpnbrq........s..c.a...k
+chancellor = c
+archbishop = s
+queen = q
+startFen = csqakbnr/pppppppp/8/8/8/8/PPPPPPPP/CSQAKBNR w - 0 1
+
+# Double Army chess
+# https://vchess.club/#/variants/Doublearmy
+[doublearmy:chess]
+pieceToCharTable = PNBRQ.....C...........Kpnbrq.....c...........k
+commoner = c
+startFen = rnbqkbnr/pppppppp/rnbqcbnr/pppppppp/PPPPPPPP/RNBQCBNR/PPPPPPPP/RNBQKBNR w KQkq - 0 1
+
+# Pawn Massacre chess
+# https://vchess.club/#/variants/Pawnmassacre
+[pawnsmassacre:chess]
+startFen = RNBKQBNR/pppppppp/8/8/8/8/PPPPPPPP/rnbkqbnr w - - 0 1
+
+# Screen chess (Below version assumes 1 drop per turn instead of the whole blind setup as in vchess)
+# https://vchess.club/#/variants/Screen 
+[screen:bughouse]
+mustDrop = true
+pieceDrops = true
+dropNoDoubled = p
+startFen = 8/8/8/8/8/8/8/8[KQRRBBNNPPPPPPPPkqrrbbnnpppppppp] w - - 0 1
+capturesToHand = false
+whiteDropRegion = *1 *2 *3 *4
+blackDropRegion = *8 *7 *6 *5
+dropOppositeColoredBishop = true
+
+# Crossing chess
+# https://vchess.club/#/variants/Crossing
+[crossing:kingofthehill]
+whiteFlag = *5
+blackFlag = *4
+
+# 4x5 Chess
+# https://greenchess.net/rules.php?v=4x5-chess --> Solved draw
+[4x5chess:gardner]
+maxRank = 5
+maxFile = d
+startFen = rnbk/pppp/4/PPPP/RNBK w - - 0 1
+
+# 4x6 Chess
+# https://greenchess.net/rules.php?v=4x6-chess --> Solved draw
+[4x6chess:gardner]
+maxRank = 6
+maxFile = d
+promotionRank = 6
+startFen = rnbk/pppp/4/4/PPPP/RNBK w - - 0 1
+
+# 5x6 chess
+# https://greenchess.net/rules.php?v=5x6-chess
+[5x6chess:gardner]
+maxRank = 6
+maxFile = e
+promotionRank = 6
+startFen = rnbqk/ppppp/5/5/PPPPP/RNBQK w - - 0 1
+
+# Active chess
+# https://greenchess.net/rules.php?v=active
+[active:chess]
+maxFile = i
+startFen = rnbkqbnrq/ppppppppp/9/9/9/9/PPPPPPPPP/RNBKQBNRQ w - - 0 1
+
+# Checkless 6x6 Atomic
+[6x6atom:nocheckatomic]
+extinctionPseudoRoyal = true
+maxRank = 6
+maxFile = f
+promotionRank = 6
+doubleStep = false
+startFen = rbqkbr/pppppp/6/6/PPPPPP/RBQKBR w - - 0 1
+
+# Advanced Pawn chess
+# https://greenchess.net/rules.php?v=advanced-pawn
+[advancedpawn:chess]
+doubleStep = false
+startFen = rnbqkbnr/8/pppppppp/8/8/PPPPPPPP/8/RNBQKBNR w KQkq - 0 1
+
+# Capture-all Chess
+# https://greenchess.net/rules.php?v=capture-all
+[captureall:giveaway]
+stalemateValue = draw
+mustCapture = false
+
+# Corner Rook Chess
+# https://greenchess.net/rules.php?v=corner-rook
+[cornerrook:chess]
+doubleStep = false
+castling = false
+startFen = r6r/1nbqkbn1/pppppppp/8/8/PPPPPPPP/1NBQKBN1/R6R w - - 0 1
+
+# Diana Chess // Kingside castling not working!
+# https://greenchess.net/rules.php?v=diana
+[diana:gardner]
+maxRank = 6
+maxFile = f
+promotionRank = 6
+doubleStep = false
+castling = true
+castlingKingsideFile = e
+castlingQueensideFile = b
+startFen = rbnkbr/pppppp/6/6/PPPPPP/RBNKBR w KQkq - 0 1
+
+# Microchess
+# https://greenchess.net/rules.php?v=microchess
+[microchess:gardner]
+maxRank = 5
+maxFile = d
+startFen = rbnk/p3/4/3P/RBNK w - - 0 1

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -67,14 +67,11 @@
 # shogiPawn
 # lance
 # shogiKnight
-# euroshogiKnight
 # gold
 # dragonHorse
 # clobber
 # breakthrough
 # immobile (piece without moves)
-# ataxx (mDNA)
-# quietQueen
 # cannon
 # janggiCannon
 # soldier
@@ -86,6 +83,32 @@
 # commoner (non-royal king)
 # centaur (=knight+commoner)
 # king
+
+### Custom pieces
+# Custom pieces can be defined by using one of the available slots:
+# customPiece1, customPiece2, ..., customPiece26
+# E.g., pawns without double steps could be described as:
+# customPiece1 = p:mfWcfF
+#
+# The movements of custom pieces can be defined using the Betza notation.
+# https://www.gnu.org/software/xboard/Betza.html
+# In Fairy-Stockfish only a subset of Betza notation can be used. The supported features are:
+# - all base moves/atoms (W, F, etc.)
+# - all directional modifiers (f, b, etc.)
+# - unlimited distance sliders for W/R and F/B directions
+# - hoppers for W/R directions, i.e., pR
+# - lame leapers (n) for N and A directions, i.e., nN and nA
+
+### Piece values
+# The predefined and precalculated piece values can be overriden
+# by specifying the pieceValueMg and pieceValueEg options, e.g.,
+# pieceValueMg = p:150 n:800
+# pieceValueEg = p:200 n:900
+#
+# For orientation, the internal predefined piece values can be found in types.h.
+# A suitable piece for gauging the piece values is the rook, which internally has:
+# pieceValueMg = r:1276
+# pieceValueEg = r:1380
 
 ### Option types
 # [bool]: boolean flag to enable/disable a feature [true, false]
@@ -99,10 +122,16 @@
 # [CountingRule]: makruk or ASEAN counting rules [makruk, asean, none]
 # [EnclosingRule]: reversi or ataxx enclosing rules [reversi, ataxx, none]
 
-### Rule definition options
-# variantTemplate: only relevant for usage in XBoard/WinBoard GUI [values: fairy, shogi] (default: fairy)
-# pieceToCharTable: mapping of piece characters to images for XBoard/WinBoard GUI (default: -)
+### Additional options relevant for usage in Winboard/XBoard
+# A few options only have the purpose of improving compatibility with Winboard/Xboard.
+# These do not need to be specified when using other GUIs, but can be essential for Winboard/Xboard.
+#
+# variantTemplate: base variant to inherit GUI logic from [values: fairy, shogi, bughouse] (default: fairy)
+# pieceToCharTable: mapping of piece characters to images,
+#                   see https://www.gnu.org/software/xboard/whats_new/4.9.0/index.html#tag-B1 (default: -)
 # pocketSize: number of pockets shown by XBoard/WinBoard for drop variants [int] (default: 0)
+
+### Rule definition options
 # maxRank: maximum rank [Rank] (default: 8)
 # maxFile: maximum file [File] (default: 8)
 # chess960: allow chess960 castling [bool] (default: false)
@@ -120,7 +149,6 @@
 # mandatoryPiecePromotion: piece promotion (and demotion if enabled) is mandatory [bool] (default: false)
 # pieceDemotion: enable demotion of pieces (e.g., Kyoto shogi) [bool] (default: false)
 # blastOnCapture: captures explode all adjacent non-pawn pieces (e.g., atomic chess) [bool] (default: false)
-# endgameEval: enable special endgame evaluation (for very chess-like variants only) [bool] (default: false)
 # doubleStep: enable pawn double step [bool] (default: true)
 # doubleStepRank: relative rank from where pawn double steps are allowed [Rank] (default: 2)
 # doubleStepRankMin: earlist relative rank from where pawn double steps are allowed [Rank] (default: 2)
@@ -421,8 +449,7 @@ whiteDropRegion = *1 *2 *3 *4 *5
 blackDropRegion = *4 *5 *6 *7 *8
 immobilityIllegal = true
 
-# Orda: Asymmetric variant with one army using pieces that move like knights but attack like other pieces (kniroo and knibis)
-# https://www.pychess.org/variant/orda
+# Asymmetric variant with one army using pieces that move like knights but attack like other pieces (kniroo and knibis)
 [orda:chess]
 pieceToCharTable = PNBRQ..AH...........LKp...q..ah.y.........lk
 centaur = h
@@ -431,6 +458,20 @@ kniroo = l
 silver = y
 promotionPieceTypes = qh
 startFen = lhaykahl/8/pppppppp/8/8/8/PPPPPPPP/RNBQKBNR w KQ - 0 1
+flagPiece = k
+whiteFlag = *8
+blackFlag = *1
+
+# Ordamirror
+# https://vchess.club/#/variants/Ordamirror
+[ordamirror:chess]
+pieceToCharTable = P...Q..AH.F.........LKp...q..ah.f.........lk
+centaur = h
+knibis = a
+kniroo = l
+customPiece1 = f:mQcN
+promotionPieceTypes = qh
+startFen = lhafkahl/8/pppppppp/8/8/PPPPPPPP/8/LHAFKAHL w - - 0 1
 flagPiece = k
 whiteFlag = *8
 blackFlag = *1
@@ -466,29 +507,6 @@ blackFlag = *1
 [capture:chess]
 mustCapture = true
 
-# Ordamirror
-# https://vchess.club/#/variants/Ordamirror
-[ordamirror:chess]
-pieceToCharTable = P...Q..AH.Y.........LKp...q..ah.y.........lk
-centaur = h
-knibis = a
-kniroo = l
-silver = y
-promotionPieceTypes = qh
-startFen = lhaykahl/8/pppppppp/8/8/PPPPPPPP/8/LHAYKAHL w - 0 1
-flagPiece = k
-whiteFlag = *8
-blackFlag = *1
-
-# Perfect chess
-# https://vchess.club/#/variants/Perfect
-[perfect:amazon]
-pieceToCharTable = PNBRQ........S..C.A...Kpnbrq........s..c.a...k
-chancellor = c
-archbishop = s
-queen = q
-startFen = csqakbnr/pppppppp/8/8/8/8/PPPPPPPP/CSQAKBNR w - 0 1
-
 # Double Army chess
 # https://vchess.club/#/variants/Doublearmy
 [doublearmy:chess]
@@ -503,15 +521,11 @@ startFen = RNBKQBNR/pppppppp/8/8/8/8/PPPPPPPP/rnbkqbnr w - - 0 1
 
 # Screen chess (Below version assumes 1 drop per turn instead of the whole blind setup as in vchess)
 # https://vchess.club/#/variants/Screen 
-[screen:bughouse]
-mustDrop = true
-pieceDrops = true
+[screen:placement]
 dropNoDoubled = p
 startFen = 8/8/8/8/8/8/8/8[KQRRBBNNPPPPPPPPkqrrbbnnpppppppp] w - - 0 1
-capturesToHand = false
 whiteDropRegion = *1 *2 *3 *4
 blackDropRegion = *8 *7 *6 *5
-dropOppositeColoredBishop = true
 
 # Crossing chess
 # https://vchess.club/#/variants/Crossing
@@ -546,7 +560,7 @@ startFen = rnbqk/ppppp/5/5/PPPPP/RNBQK w - - 0 1
 # https://greenchess.net/rules.php?v=active
 [active:chess]
 maxFile = i
-startFen = rnbkqbnrq/ppppppppp/9/9/9/9/PPPPPPPPP/RNBKQBNRQ w - - 0 1
+startFen = rnbkqbnrq/ppppppppp/9/9/9/9/PPPPPPPPP/RNBKQBNRQ w KQkq 0 1
 
 # Checkless 6x6 Atomic
 [6x6atom:nocheckatomic]
@@ -565,9 +579,8 @@ startFen = rnbqkbnr/8/pppppppp/8/8/PPPPPPPP/8/RNBQKBNR w KQkq - 0 1
 
 # Capture-all Chess
 # https://greenchess.net/rules.php?v=capture-all
-[captureall:giveaway]
-stalemateValue = draw
-mustCapture = false
+[captureall:extinction]
+extinctionPieceTypes = *
 
 # Corner Rook Chess
 # https://greenchess.net/rules.php?v=corner-rook
@@ -578,11 +591,8 @@ startFen = r6r/1nbqkbn1/pppppppp/8/8/PPPPPPPP/1NBQKBN1/R6R w - - 0 1
 
 # Diana Chess // Kingside castling not working!
 # https://greenchess.net/rules.php?v=diana
-[diana:gardner]
-maxRank = 6
-maxFile = f
-promotionRank = 6
-doubleStep = false
+[diana:losalamos]
+promotionPieceTypes = rbn
 castling = true
 castlingKingsideFile = e
 castlingQueensideFile = b
@@ -594,3 +604,48 @@ startFen = rbnkbr/pppppp/6/6/PPPPPP/RBNKBR w KQkq - 0 1
 maxRank = 5
 maxFile = d
 startFen = rbnk/p3/4/3P/RBNK w - - 0 1
+
+# Empire Chess
+# https://vchess.club/#/variants/Empire
+[empire:chess]
+pieceToCharTable = PNBRQ.....ST.C.D.E...Kpnbrq.....st.c.d.e...k
+customPiece1 = e:mQcN
+customPiece2 = c:mQcB
+customPiece3 = t:mQcR
+customPiece4 = d:mQcK
+soldier = s
+promotionPieceTypes = qne
+startFen = rnbqkbnr/pppppppp/8/8/8/PPPSSPPP/8/TECDKCET w kq - 0 1
+stalemateValue = loss
+nFoldValue = loss
+flagPiece = k
+whiteFlag = *8
+blackFlag = *1
+flyingGeneral = true
+
+# Shinobi Chess
+# https://vchess.club/#/variants/Shinobi
+[shinobi:crazyhouse]
+variantTemplate = shogi
+pieceToCharTable = PNBRQ.DJMLH.....CKpnbrq.djmlh.....ck
+pocketSize = 8
+commoner = c
+bers = d
+archbishop = j
+fers = m
+shogiKnight = h
+lance = l
+promotionRank = 7
+promotionPieceTypes = -
+promotedPieceType = p:c m:b h:n l:r
+mandatoryPiecePromotion = true
+stalemateValue = loss
+perpetualCheckIllegal = true
+startFen = rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/LH1CK1HL[LHMMDJ] w kq - 0 1
+capturesToHand = false
+whiteDropRegion = *1 *2 *3 *4
+blackDropRegion = *5 *6 *7 *8
+immobilityIllegal = true
+flagPiece = k
+whiteFlag = *8
+blackFlag = *1


### PR DESCRIPTION
Fix the following variants:

- Orda // https://www.pychess.org/variant/orda

Add support for the following variants:

- 4x5 Chess // https://greenchess.net/rules.php?v=4x5-chess --> Solved draw
- 4x6 Chess // https://greenchess.net/rules.php?v=4x6-chess --> Solved draw
- 5x6 chess // https://greenchess.net/rules.php?v=5x6-chess
- Active chess // https://greenchess.net/rules.php?v=active
- Advanced Pawn chess // https://greenchess.net/rules.php?v=advanced-pawn
- Capture-all Chess // https://greenchess.net/rules.php?v=capture-all
- Capture chess // https://vchess.club/#/variants/Capture
- Checkless 6x6 Atomic // Checkless atomic on a 6x6 board
- Corner Rook Chess // https://greenchess.net/rules.php?v=corner-rook
- Crossing chess // https://vchess.club/#/variants/Crossing
- Diana Chess // https://greenchess.net/rules.php?v=diana (Kingside castling not working)
- Double Army chess // https://vchess.club/#/variants/Doublearmy
- Goth House // Gothic Chess + Crazyhouse
- Microchess // https://greenchess.net/rules.php?v=microchess
- Ordamirror // https://vchess.club/#/variants/Ordamirror
- Pawn Massacre chess // https://vchess.club/#/variants/Pawnmassacre
- Perfect chess // https://vchess.club/#/variants/Perfect
- Screen chess // https://vchess.club/#/variants/Screen (This version assumes 1 drop per turn instead of the whole blind setup as in vchess)
- Synochess // https://www.pychess.org/variant/synochess