### PR TITLE
Port wider UCI_Elo range from ddugovic/Stockfish (closes #316)

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -391,12 +391,9 @@ void Thread::search() {
 
   // Pick integer skill levels, but non-deterministically round up or down
   // such that the average integer skill corresponds to the input floating point one.
-  // UCI_Elo is converted to a suitable fractional skill level, using anchoring
-  // to CCRL Elo (goldfish 1.13 = 2000) and a fit through Ordo derived Elo
-  // for match (TC 60+0.6) results spanning a wide range of k values.
   PRNG rng(now());
   double floatLevel = Options["UCI_LimitStrength"] ?
-                      std::clamp(std::pow((Options["UCI_Elo"] - 1346.6) / 143.4, 1 / 0.806), 0.0, 20.0) :
+                      std::clamp((Options["UCI_Elo"] - 1500.0) / 75.0, -20.0, 20.0) :
                         double(Options["Skill Level"]);
   int intLevel = int(floatLevel) +
                  ((floatLevel - int(floatLevel)) * 1024 > rng.rand<unsigned>() % 1024  ? 1 : 0);

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -183,7 +183,7 @@ void init(OptionsMap& o) {
   o["UCI_Variant"]           << Option("chess", variants.get_keys(), on_variant_change);
   o["UCI_AnalyseMode"]       << Option(false);
   o["UCI_LimitStrength"]     << Option(false);
-  o["UCI_Elo"]               << Option(1350, 1350, 2850);
+  o["UCI_Elo"]               << Option(1350, 0, 3000);
   o["UCI_ShowWDL"]           << Option(false);
   o["SyzygyPath"]            << Option("<empty>", on_tb_path);
   o["SyzygyProbeDepth"]      << Option(1, 1, 100);


### PR DESCRIPTION
The Skill Level option already allowed values from -20 to 20, but not via UCI_Elo. Expands the UCI_Elo range to linearly correspond to the entire range of levels.

The linear interpolation is almost equivalent to the original Elo -> Skill level mapping:

![image](https://user-images.githubusercontent.com/402777/119259640-72962900-bbcf-11eb-971e-a2f9f26ef2b2.png)
