### PR TITLE
Support lower UCI Elo levels

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -395,8 +395,11 @@ void Thread::search() {
   // to CCRL Elo (goldfish 1.13 = 2000) and a fit through Ordo derived Elo
   // for match (TC 60+0.6) results spanning a wide range of k values.
   PRNG rng(now());
+  double shiftedElo = Options["UCI_Elo"] - 1346.6;
   double floatLevel = Options["UCI_LimitStrength"] ?
-                      std::clamp(std::pow((Options["UCI_Elo"] - 1346.6) / 143.4, 1 / 0.806), 0.0, 20.0) :
+                      std::clamp(shiftedElo > 0 ? std::pow(shiftedElo / 143.4, 1 / 0.806)
+                                                : shiftedElo / 143.4 + std::pow(shiftedElo / 500, 5),
+                                 -20.0, 20.0) :
                         double(Options["Skill Level"]);
   int intLevel = int(floatLevel) +
                  ((floatLevel - int(floatLevel)) * 1024 > rng.rand<unsigned>() % 1024  ? 1 : 0);

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -183,7 +183,7 @@ void init(OptionsMap& o) {
   o["UCI_Variant"]           << Option("chess", variants.get_keys(), on_variant_change);
   o["UCI_AnalyseMode"]       << Option(false);
   o["UCI_LimitStrength"]     << Option(false);
-  o["UCI_Elo"]               << Option(1350, 1350, 2850);
+  o["UCI_Elo"]               << Option(1350, 500, 2850);
   o["UCI_ShowWDL"]           << Option(false);
   o["SyzygyPath"]            << Option("<empty>", on_tb_path);
   o["SyzygyProbeDepth"]      << Option(1, 1, 100);


### PR DESCRIPTION
Extends UCI_Elo range to support negative Skill Levels also via corresponding UCI_Elo values.

Edit: In a short test the correlation between UCI_Elo and ordo rating looks good. 
```
   # PLAYER    :  RATING  POINTS  PLAYED   (%)
   1 1400      :  1400.0    47.0      56    84
   2 1200      :  1376.7    46.0      56    82
   3 1000      :  1365.2    45.5      56    81
   4 900       :  1102.9    34.0      56    61
   5 800       :   803.0    22.0      56    39
   6 700       :   583.6    12.5      56    22
   7 600       :   502.6     9.0      56    16
   8 500       :   478.3     8.0      56    14
```