### PR TITLE
Merge HalfKAv2 architecture

### DIFF
--- a/.github/workflows/fairy.yml
+++ b/.github/workflows/fairy.yml
@@ -55,6 +55,12 @@ jobs:
           make -j2 ARCH=x86-64 nnue=yes debug=yes build
           ./stockfish bench
 
+      - name: Test NNUE largeboards
+        run: |
+          make clean
+          make -j2 ARCH=x86-64 largeboards=yes nnue=yes debug=yes build
+          ./stockfish bench
+
       - name: Build all variants
         run: |
           make clean

--- a/src/Makefile
+++ b/src/Makefile
@@ -41,9 +41,9 @@ endif
 SRCS = benchmark.cpp bitbase.cpp bitboard.cpp endgame.cpp evaluate.cpp main.cpp \
 	material.cpp misc.cpp movegen.cpp movepick.cpp pawns.cpp position.cpp psqt.cpp \
 	search.cpp thread.cpp timeman.cpp tt.cpp uci.cpp ucioption.cpp tune.cpp syzygy/tbprobe.cpp \
-	nnue/evaluate_nnue.cpp nnue/features/half_kp.cpp \
+	nnue/evaluate_nnue.cpp nnue/features/half_ka_v2.cpp \
 	partner.cpp parser.cpp piece.cpp variant.cpp xboard.cpp \
-	nnue/features/half_kp_shogi.cpp nnue/features/half_kp_variants.cpp
+	nnue/features/half_ka_v2_shogi.cpp nnue/features/half_ka_v2_variants.cpp
 
 OBJS = $(notdir $(SRCS:.cpp=.o))
 

--- a/src/Makefile_js
+++ b/src/Makefile_js
@@ -19,9 +19,9 @@ EXE = ../tests/js/ffish.js
 SRCS = ffishjs.cpp benchmark.cpp bitbase.cpp bitboard.cpp endgame.cpp evaluate.cpp \
 	material.cpp misc.cpp movegen.cpp movepick.cpp pawns.cpp position.cpp psqt.cpp \
 	search.cpp thread.cpp timeman.cpp tt.cpp uci.cpp ucioption.cpp tune.cpp syzygy/tbprobe.cpp \
-	nnue/evaluate_nnue.cpp nnue/features/half_kp.cpp \
+	nnue/evaluate_nnue.cpp nnue/features/half_ka_v2.cpp \
 	partner.cpp parser.cpp piece.cpp variant.cpp xboard.cpp \
-	nnue/features/half_kp_shogi.cpp nnue/features/half_kp_variants.cpp
+	nnue/features/half_ka_v2_shogi.cpp nnue/features/half_ka_v2_variants.cpp
 
 CXX=emcc
 CXXFLAGS += --bind -DNNUE_EMBEDDING_OFF -DNO_THREADS -std=c++17 -Wall

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -147,7 +147,7 @@ namespace Eval {
 
     if (filename.has_value())
         actualFilename = filename.value();
-    else 
+    else
     {
         if (eval_file_loaded != EvalFileDefaultName)
         {
@@ -1603,10 +1603,8 @@ Value Eval::evaluate(const Position& pos) {
       // Scale and shift NNUE for compatibility with search and classical evaluation
       auto  adjusted_NNUE = [&]()
       {
-         int material = pos.non_pawn_material() + 4 * PawnValueMg * pos.count<PAWN>();
-         int scale =  580
-                    + material / 32
-                    - 4 * pos.rule50_count();
+
+         int scale = 903 + 28 * pos.count<PAWN>() + 28 * pos.non_pawn_material() / 1024;
 
          Value nnue = NNUE::evaluate(pos) * scale / 1024 + Time.tempoNNUE;
 
@@ -1616,8 +1614,8 @@ Value Eval::evaluate(const Position& pos) {
          if (pos.check_counting())
          {
              Color us = pos.side_to_move();
-             nnue +=  material / (30 * pos.checks_remaining( us))
-                    - material / (30 * pos.checks_remaining(~us));
+             nnue +=  6 * scale / (5 * pos.checks_remaining( us))
+                    - 6 * scale / (5 * pos.checks_remaining(~us));
          }
 
          return nnue;
@@ -1629,7 +1627,7 @@ Value Eval::evaluate(const Position& pos) {
       int   r50 = 16 + pos.rule50_count();
       bool  pure = !pos.check_counting();
       bool  largePsq = psq * 16 > (NNUEThreshold1 + pos.non_pawn_material() / 64) * r50 && !pure;
-      bool  classical = largePsq || (psq > PawnValueMg / 4 && !(pos.this_thread()->nodes & 0xB) && !pure);
+      bool  classical = largePsq;
 
       // Use classical evaluation for really low piece endgames.
       // One critical case is the draw for bishop + A/H file pawn vs naked king.
@@ -1646,8 +1644,7 @@ Value Eval::evaluate(const Position& pos) {
           && !lowPieceEndgame
           && (   abs(v) * 16 < NNUEThreshold2 * r50
               || (   pos.opposite_bishops()
-                  && abs(v) * 16 < (NNUEThreshold1 + pos.non_pawn_material() / 64) * r50
-                  && !(pos.this_thread()->nodes & 0xB))))
+                  && abs(v) * 16 < (NNUEThreshold1 + pos.non_pawn_material() / 64) * r50)))
           v = adjusted_NNUE();
   }
 

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -40,7 +40,7 @@ namespace Eval {
   // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
   // for the build process (profile-build and fishtest) to work. Do not change the
   // name of the macro, as it is used in the Makefile.
-  #define EvalFileDefaultName   "nn-62ef826d1a6d.nnue"
+  #define EvalFileDefaultName   "nn-8a08400ed089.nnue"
 
   namespace NNUE {
 

--- a/src/nnue/features/half_ka_v2.cpp
+++ b/src/nnue/features/half_ka_v2.cpp
@@ -16,9 +16,9 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-//Definition of input features HalfKP of NNUE evaluation function
+//Definition of input features HalfKAv2 of NNUE evaluation function
 
-#include "half_kp.h"
+#include "half_ka_v2.h"
 
 #include "../../position.h"
 
@@ -30,23 +30,23 @@ namespace Stockfish::Eval::NNUE::Features {
   }
 
   // Orient a square according to perspective (rotates by 180 for black)
-  inline Square HalfKPChess::orient(Color perspective, Square s) {
-    return Square(int(to_chess_square(s)) ^ (bool(perspective) * 63));
+  inline Square HalfKAv2::orient(Color perspective, Square s) {
+    return Square(int(to_chess_square(s)) ^ (bool(perspective) * 56));
   }
 
   // Index of a feature for a given king position and another piece on some square
-  inline IndexType HalfKPChess::make_index(Color perspective, Square s, Piece pc, Square ksq) {
+  inline IndexType HalfKAv2::make_index(Color perspective, Square s, Piece pc, Square ksq) {
     return IndexType(orient(perspective, s) + PieceSquareIndex[perspective][pc] + PS_NB * ksq);
   }
 
   // Get a list of indices for active features
-  void HalfKPChess::append_active_indices(
+  void HalfKAv2::append_active_indices(
     const Position& pos,
     Color perspective,
     ValueListInserter<IndexType> active
   ) {
-    Square ksq = orient(perspective, pos.square(perspective, pos.nnue_king()));
-    Bitboard bb = pos.pieces() & ~pos.pieces(pos.nnue_king());
+    Square ksq = orient(perspective, pos.square<KING>(perspective));
+    Bitboard bb = pos.pieces();
     while (bb)
     {
       Square s = pop_lsb(bb);
@@ -57,19 +57,17 @@ namespace Stockfish::Eval::NNUE::Features {
 
   // append_changed_indices() : get a list of indices for recently changed features
 
-  void HalfKPChess::append_changed_indices(
+  void HalfKAv2::append_changed_indices(
     Square ksq,
     StateInfo* st,
     Color perspective,
     ValueListInserter<IndexType> removed,
-    ValueListInserter<IndexType> added,
-    const Position& pos
+    ValueListInserter<IndexType> added
   ) {
     const auto& dp = st->dirtyPiece;
     Square oriented_ksq = orient(perspective, ksq);
     for (int i = 0; i < dp.dirty_num; ++i) {
       Piece pc = dp.piece[i];
-      if (type_of(pc) == pos.nnue_king()) continue;
       if (dp.from[i] != SQ_NONE)
         removed.push_back(make_index(perspective, dp.from[i], pc, oriented_ksq));
       if (dp.to[i] != SQ_NONE)
@@ -77,16 +75,16 @@ namespace Stockfish::Eval::NNUE::Features {
     }
   }
 
-  int HalfKPChess::update_cost(StateInfo* st) {
+  int HalfKAv2::update_cost(StateInfo* st) {
     return st->dirtyPiece.dirty_num;
   }
 
-  int HalfKPChess::refresh_cost(const Position& pos) {
-    return pos.count<ALL_PIECES>() - 2;
+  int HalfKAv2::refresh_cost(const Position& pos) {
+    return pos.count<ALL_PIECES>();
   }
 
-  bool HalfKPChess::requires_refresh(StateInfo* st, Color perspective, const Position& pos) {
-    return st->dirtyPiece.piece[0] == make_piece(perspective, pos.nnue_king());
+  bool HalfKAv2::requires_refresh(StateInfo* st, Color perspective) {
+    return st->dirtyPiece.piece[0] == make_piece(perspective, KING);
   }
 
 }  // namespace Stockfish::Eval::NNUE::Features

--- a/src/nnue/features/half_ka_v2.h
+++ b/src/nnue/features/half_ka_v2.h
@@ -16,18 +16,15 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-//Definition of input features HalfKP of NNUE evaluation function
+//Definition of input features HalfKAv2 of NNUE evaluation function
 
-#ifndef NNUE_FEATURES_HALF_KP_VARIANTS_H_INCLUDED
-#define NNUE_FEATURES_HALF_KP_VARIANTS_H_INCLUDED
+#ifndef NNUE_FEATURES_HALF_KA_V2_H_INCLUDED
+#define NNUE_FEATURES_HALF_KA_V2_H_INCLUDED
 
 #include "../nnue_common.h"
 
 #include "../../evaluate.h"
 #include "../../misc.h"
-
-#include "half_kp_shogi.h"
-#include "half_kp.h"
 
 namespace Stockfish {
   struct StateInfo;
@@ -35,104 +32,96 @@ namespace Stockfish {
 
 namespace Stockfish::Eval::NNUE::Features {
 
-  // Feature HalfKP: Combination of the position of own king
-  // and the position of pieces other than kings
-  class HalfKPVariants {
+  // Feature HalfKAv2: Combination of the position of own king
+  // and the position of pieces
+  class HalfKAv2 {
 
     // unique number for each piece type on each square
     enum {
       PS_NONE     =  0,
-      PS_W_PAWN   =  1,
-      PS_B_PAWN   =  1 * SQUARE_NB_CHESS + 1,
-      PS_W_KNIGHT =  2 * SQUARE_NB_CHESS + 1,
-      PS_B_KNIGHT =  3 * SQUARE_NB_CHESS + 1,
-      PS_W_BISHOP =  4 * SQUARE_NB_CHESS + 1,
-      PS_B_BISHOP =  5 * SQUARE_NB_CHESS + 1,
-      PS_W_ROOK   =  6 * SQUARE_NB_CHESS + 1,
-      PS_B_ROOK   =  7 * SQUARE_NB_CHESS + 1,
-      PS_W_QUEEN  =  8 * SQUARE_NB_CHESS + 1,
-      PS_B_QUEEN  =  9 * SQUARE_NB_CHESS + 1,
-      PS_NB       = 10 * SQUARE_NB_CHESS + 1,
+      PS_W_PAWN   =  0,
+      PS_B_PAWN   =  1 * SQUARE_NB_CHESS,
+      PS_W_KNIGHT =  2 * SQUARE_NB_CHESS,
+      PS_B_KNIGHT =  3 * SQUARE_NB_CHESS,
+      PS_W_BISHOP =  4 * SQUARE_NB_CHESS,
+      PS_B_BISHOP =  5 * SQUARE_NB_CHESS,
+      PS_W_ROOK   =  6 * SQUARE_NB_CHESS,
+      PS_B_ROOK   =  7 * SQUARE_NB_CHESS,
+      PS_W_QUEEN  =  8 * SQUARE_NB_CHESS,
+      PS_B_QUEEN  =  9 * SQUARE_NB_CHESS,
+      PS_KING     =  10 * SQUARE_NB_CHESS,
+      PS_NB = 11 * SQUARE_NB_CHESS
     };
 
     static constexpr uint32_t PieceSquareIndex[COLOR_NB][PIECE_NB] = {
       // convention: W - us, B - them
       // viewed from other side, W and B are reversed
       {
-        PS_NONE, PS_W_PAWN, PS_W_KNIGHT, PS_W_BISHOP, PS_W_ROOK, PS_W_QUEEN, PS_W_QUEEN, PS_W_BISHOP,
-        PS_W_BISHOP, PS_W_BISHOP, PS_W_QUEEN, PS_W_QUEEN, PS_NONE, PS_NONE, PS_W_QUEEN, PS_W_KNIGHT,
-        PS_W_BISHOP, PS_W_KNIGHT, PS_W_ROOK, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
-        PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_W_BISHOP, PS_NONE, PS_W_PAWN, PS_W_KNIGHT, PS_NONE,
+        PS_NONE, PS_W_PAWN, PS_W_KNIGHT, PS_W_BISHOP, PS_W_ROOK, PS_W_QUEEN, PS_NONE, PS_NONE,
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
+        PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
+        PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
+        PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_KING,
 
         PS_NONE, PS_B_PAWN, PS_B_KNIGHT, PS_B_BISHOP, PS_B_ROOK, PS_B_QUEEN, PS_B_QUEEN, PS_B_BISHOP,
-        PS_B_BISHOP, PS_B_BISHOP, PS_B_QUEEN, PS_B_QUEEN, PS_NONE, PS_NONE, PS_B_QUEEN, PS_B_KNIGHT,
-        PS_B_BISHOP, PS_B_KNIGHT, PS_B_ROOK, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
-        PS_NONE, PS_NONE, PS_NONE, PS_B_BISHOP, PS_NONE, PS_B_PAWN, PS_B_KNIGHT, PS_NONE,
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
+        PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
+        PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
+        PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_KING,
       },
 
       {
         PS_NONE, PS_B_PAWN, PS_B_KNIGHT, PS_B_BISHOP, PS_B_ROOK, PS_B_QUEEN, PS_B_QUEEN, PS_B_BISHOP,
-        PS_B_BISHOP, PS_B_BISHOP, PS_B_QUEEN, PS_B_QUEEN, PS_NONE, PS_NONE, PS_B_QUEEN, PS_B_KNIGHT,
-        PS_B_BISHOP, PS_B_KNIGHT, PS_B_ROOK, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
-        PS_NONE, PS_NONE, PS_NONE, PS_B_BISHOP, PS_NONE, PS_B_PAWN, PS_B_KNIGHT, PS_NONE,
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
+        PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
+        PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
+        PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_KING,
 
-        PS_NONE, PS_W_PAWN, PS_W_KNIGHT, PS_W_BISHOP, PS_W_ROOK, PS_W_QUEEN, PS_W_QUEEN, PS_W_BISHOP,
-        PS_W_BISHOP, PS_W_BISHOP, PS_W_QUEEN, PS_W_QUEEN, PS_NONE, PS_NONE, PS_W_QUEEN, PS_W_KNIGHT,
-        PS_W_BISHOP, PS_W_KNIGHT, PS_W_ROOK, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
-        PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_W_BISHOP, PS_NONE, PS_W_PAWN, PS_W_KNIGHT, PS_NONE,
+        PS_NONE, PS_W_PAWN, PS_W_KNIGHT, PS_W_BISHOP, PS_W_ROOK, PS_W_QUEEN, PS_NONE, PS_NONE,
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
+        PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
+        PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
+        PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_KING,
       }
     };
     // Check that the fragile array definition is correct
     static_assert(PieceSquareIndex[WHITE][make_piece(WHITE, PAWN)] == PS_W_PAWN);
-    static_assert(PieceSquareIndex[WHITE][make_piece(WHITE, KING)] == PS_NONE);
+    static_assert(PieceSquareIndex[WHITE][make_piece(WHITE, KING)] == PS_KING);
     static_assert(PieceSquareIndex[WHITE][make_piece(BLACK, PAWN)] == PS_B_PAWN);
-    static_assert(PieceSquareIndex[WHITE][make_piece(BLACK, KING)] == PS_NONE);
+    static_assert(PieceSquareIndex[WHITE][make_piece(BLACK, KING)] == PS_KING);
+
 
     // Orient a square according to perspective (rotates by 180 for black)
-    static Square orient(Color perspective, Square s, const Position& pos);
+    static Square orient(Color perspective, Square s);
 
     // Index of a feature for a given king position and another piece on some square
-    static IndexType make_index(Color perspective, Square s, Piece pc, Square ksq, const Position& pos);
+    static IndexType make_index(Color perspective, Square s, Piece pc, Square ksq);
 
    public:
     // Feature name
-    static constexpr const char* Name = "HalfKP(Friend)";
+    static constexpr const char* Name = "HalfKAv2(Friend)";
 
     // Hash value embedded in the evaluation file
-    static constexpr std::uint32_t HashValue = 0x5D69D5B8u;
+    static constexpr std::uint32_t HashValue = 0x5f234cb8u;
 
     // Number of feature dimensions
     static constexpr IndexType Dimensions =
-#ifdef LARGEBOARDS
-        HalfKPShogi::Dimensions;
-#else
-        HalfKPChess::Dimensions;
-#endif
+        static_cast<IndexType>(SQUARE_NB_CHESS) * static_cast<IndexType>(PS_NB);
 
-    static IndexType get_dimensions() {
-      return  currentNnueFeatures == NNUE_SHOGI ? HalfKPShogi::Dimensions
-            : currentNnueFeatures == NNUE_CHESS ? HalfKPChess::Dimensions
-                                                : SQUARE_NB_CHESS * PS_NB;
-    }
-
-    // Maximum number of simultaneously active features. 30 because kins are not included.
-    static constexpr IndexType MaxActiveDimensions = 64;
+    // Maximum number of simultaneously active features.
+    static constexpr IndexType MaxActiveDimensions = 32;
 
     // Get a list of indices for active features
     static void append_active_indices(
@@ -146,8 +135,7 @@ namespace Stockfish::Eval::NNUE::Features {
       StateInfo* st,
       Color perspective,
       ValueListInserter<IndexType> removed,
-      ValueListInserter<IndexType> added,
-      const Position& pos);
+      ValueListInserter<IndexType> added);
 
     // Returns the cost of updating one perspective, the most costly one.
     // Assumes no refresh needed.
@@ -156,9 +144,9 @@ namespace Stockfish::Eval::NNUE::Features {
 
     // Returns whether the change stored in this StateInfo means that
     // a full accumulator refresh is required.
-    static bool requires_refresh(StateInfo* st, Color perspective, const Position& pos);
+    static bool requires_refresh(StateInfo* st, Color perspective);
   };
 
 }  // namespace Stockfish::Eval::NNUE::Features
 
-#endif // #ifndef NNUE_FEATURES_HALF_KP_VARIANTS_H_INCLUDED
+#endif // #ifndef NNUE_FEATURES_HALF_KA_V2_H_INCLUDED

--- a/src/nnue/features/half_ka_v2_shogi.h
+++ b/src/nnue/features/half_ka_v2_shogi.h
@@ -16,10 +16,10 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-//Definition of input features HalfKP of NNUE evaluation function
+//Definition of input features HalfKAv2 of NNUE evaluation function
 
-#ifndef NNUE_FEATURES_HALF_KP_SHOGI_H_INCLUDED
-#define NNUE_FEATURES_HALF_KP_SHOGI_H_INCLUDED
+#ifndef NNUE_FEATURES_HALF_KA_V2_SHOGI_H_INCLUDED
+#define NNUE_FEATURES_HALF_KA_V2_SHOGI_H_INCLUDED
 
 #include "../nnue_common.h"
 
@@ -32,27 +32,28 @@ namespace Stockfish {
 
 namespace Stockfish::Eval::NNUE::Features {
 
-  // Feature HalfKP: Combination of the position of own king
-  // and the position of pieces other than kings
-  class HalfKPShogi {
+  // Feature HalfKAv2: Combination of the position of own king
+  // and the position of pieces
+  class HalfKAv2Shogi {
 
+    // unique number for each piece type on each square
     enum {
-      PS_NONE             =  0,
-      SHOGI_HAND_W_PAWN   =   1,
-      SHOGI_HAND_B_PAWN   =  20,
-      SHOGI_HAND_W_LANCE  =  39,
-      SHOGI_HAND_B_LANCE  =  44,
-      SHOGI_HAND_W_KNIGHT =  49,
-      SHOGI_HAND_B_KNIGHT =  54,
-      SHOGI_HAND_W_SILVER =  59,
-      SHOGI_HAND_B_SILVER =  64,
-      SHOGI_HAND_W_GOLD   =  69,
-      SHOGI_HAND_B_GOLD   =  74,
-      SHOGI_HAND_W_BISHOP =  79,
-      SHOGI_HAND_B_BISHOP =  82,
-      SHOGI_HAND_W_ROOK   =  85,
-      SHOGI_HAND_B_ROOK   =  88,
-      SHOGI_HAND_END      =  90,
+      PS_NONE             =   0,
+      SHOGI_HAND_W_PAWN   =   0,
+      SHOGI_HAND_B_PAWN   =  19,
+      SHOGI_HAND_W_LANCE  =  38,
+      SHOGI_HAND_B_LANCE  =  43,
+      SHOGI_HAND_W_KNIGHT =  48,
+      SHOGI_HAND_B_KNIGHT =  53,
+      SHOGI_HAND_W_SILVER =  58,
+      SHOGI_HAND_B_SILVER =  63,
+      SHOGI_HAND_W_GOLD   =  68,
+      SHOGI_HAND_B_GOLD   =  73,
+      SHOGI_HAND_W_BISHOP =  78,
+      SHOGI_HAND_B_BISHOP =  81,
+      SHOGI_HAND_W_ROOK   =  84,
+      SHOGI_HAND_B_ROOK   =  87,
+      SHOGI_HAND_END      =  89,
 
       SHOGI_PS_W_PAWN     =  SHOGI_HAND_END,
       SHOGI_PS_B_PAWN     =  1 * SQUARE_NB_SHOGI + SHOGI_HAND_END,
@@ -72,10 +73,8 @@ namespace Stockfish::Eval::NNUE::Features {
       SHOGI_PS_B_ROOK     = 15 * SQUARE_NB_SHOGI + SHOGI_HAND_END,
       SHOGI_PS_W_DRAGON   = 16 * SQUARE_NB_SHOGI + SHOGI_HAND_END,
       SHOGI_PS_B_DRAGON   = 17 * SQUARE_NB_SHOGI + SHOGI_HAND_END,
-      SHOGI_PS_W_KING     = 18 * SQUARE_NB_SHOGI + SHOGI_HAND_END,
-      SHOGI_PS_END        = SHOGI_PS_W_KING, // pieces without kings (pawns included)
-      SHOGI_PS_B_KING     = 19 * SQUARE_NB_SHOGI + SHOGI_HAND_END,
-      SHOGI_PS_END2       = 20 * SQUARE_NB_SHOGI + SHOGI_HAND_END
+      SHOGI_PS_KING       = 18 * SQUARE_NB_SHOGI + SHOGI_HAND_END,
+      SHOGI_PS_NB         = 19 * SQUARE_NB_SHOGI + SHOGI_HAND_END,
     };
 
     static constexpr uint32_t PieceSquareIndexShogi[COLOR_NB][PIECE_NB] = {
@@ -89,7 +88,7 @@ namespace Stockfish::Eval::NNUE::Features {
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
-        PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, SHOGI_PS_W_KING,
+        PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, SHOGI_PS_KING,
 
         PS_NONE, PS_NONE, PS_NONE, SHOGI_PS_B_BISHOP, SHOGI_PS_B_ROOK, PS_NONE, PS_NONE, PS_NONE,
         PS_NONE, SHOGI_PS_B_SILVER, PS_NONE, SHOGI_PS_B_DRAGON, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
@@ -98,7 +97,7 @@ namespace Stockfish::Eval::NNUE::Features {
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
-        PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, SHOGI_PS_B_KING
+        PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, SHOGI_PS_KING
       },
 
       {
@@ -109,7 +108,7 @@ namespace Stockfish::Eval::NNUE::Features {
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
-        PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, SHOGI_PS_B_KING,
+        PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, SHOGI_PS_KING,
 
         PS_NONE, PS_NONE, PS_NONE, SHOGI_PS_W_BISHOP, SHOGI_PS_W_ROOK, PS_NONE, PS_NONE, PS_NONE,
         PS_NONE, SHOGI_PS_W_SILVER, PS_NONE, SHOGI_PS_W_DRAGON, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
@@ -118,13 +117,13 @@ namespace Stockfish::Eval::NNUE::Features {
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
-        PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, SHOGI_PS_W_KING
+        PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, SHOGI_PS_KING
       }
     };
     static_assert(PieceSquareIndexShogi[WHITE][make_piece(WHITE, SHOGI_PAWN)] == SHOGI_PS_W_PAWN);
-    static_assert(PieceSquareIndexShogi[WHITE][make_piece(WHITE, KING)] == SHOGI_PS_W_KING);
+    static_assert(PieceSquareIndexShogi[WHITE][make_piece(WHITE, KING)] == SHOGI_PS_KING);
     static_assert(PieceSquareIndexShogi[WHITE][make_piece(BLACK, SHOGI_PAWN)] == SHOGI_PS_B_PAWN);
-    static_assert(PieceSquareIndexShogi[WHITE][make_piece(BLACK, KING)] == SHOGI_PS_B_KING);
+    static_assert(PieceSquareIndexShogi[WHITE][make_piece(BLACK, KING)] == SHOGI_PS_KING);
 
     static constexpr uint32_t PieceSquareIndexShogiHand[COLOR_NB][PIECE_TYPE_NB] = {
       // convention: W - us, B - them
@@ -167,17 +166,17 @@ namespace Stockfish::Eval::NNUE::Features {
 
    public:
     // Feature name
-    static constexpr const char* Name = "HalfKP(Friend)";
+    static constexpr const char* Name = "HalfKAv2(Friend)";
 
     // Hash value embedded in the evaluation file
-    static constexpr std::uint32_t HashValue = 0x5D69D5B8u;
+    static constexpr std::uint32_t HashValue = 0x5f234cb8u;
 
     // Number of feature dimensions
     static constexpr IndexType Dimensions =
-        static_cast<IndexType>(SQUARE_NB_SHOGI) * static_cast<IndexType>(SHOGI_PS_END);
+        static_cast<IndexType>(SQUARE_NB_SHOGI) * static_cast<IndexType>(SHOGI_PS_NB);
 
-    // Maximum number of simultaneously active features. 38 because kins are not included.
-    static constexpr IndexType MaxActiveDimensions = 38;
+    // Maximum number of simultaneously active features.
+    static constexpr IndexType MaxActiveDimensions = 40;
 
     // Get a list of indices for active features
     static void append_active_indices(
@@ -191,8 +190,7 @@ namespace Stockfish::Eval::NNUE::Features {
       StateInfo* st,
       Color perspective,
       ValueListInserter<IndexType> removed,
-      ValueListInserter<IndexType> added,
-      const Position& pos);
+      ValueListInserter<IndexType> added);
 
     // Returns the cost of updating one perspective, the most costly one.
     // Assumes no refresh needed.
@@ -201,9 +199,9 @@ namespace Stockfish::Eval::NNUE::Features {
 
     // Returns whether the change stored in this StateInfo means that
     // a full accumulator refresh is required.
-    static bool requires_refresh(StateInfo* st, Color perspective, const Position& pos);
+    static bool requires_refresh(StateInfo* st, Color perspective);
   };
 
 }  // namespace Stockfish::Eval::NNUE::Features
 
-#endif // #ifndef NNUE_FEATURES_HALF_KP_SHOGI_H_INCLUDED
+#endif // #ifndef NNUE_FEATURES_HALF_KA_V2_SHOGI_H_INCLUDED

--- a/src/nnue/features/half_ka_v2_variants.h
+++ b/src/nnue/features/half_ka_v2_variants.h
@@ -16,15 +16,18 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-//Definition of input features HalfKP of NNUE evaluation function
+//Definition of input features HalfKAv2 of NNUE evaluation function
 
-#ifndef NNUE_FEATURES_HALF_KP_H_INCLUDED
-#define NNUE_FEATURES_HALF_KP_H_INCLUDED
+#ifndef NNUE_FEATURES_HALF_KA_V2_VARIANTS_H_INCLUDED
+#define NNUE_FEATURES_HALF_KA_V2_VARIANTS_H_INCLUDED
 
 #include "../nnue_common.h"
 
 #include "../../evaluate.h"
 #include "../../misc.h"
+
+#include "half_ka_v2_shogi.h"
+#include "half_ka_v2.h"
 
 namespace Stockfish {
   struct StateInfo;
@@ -32,24 +35,25 @@ namespace Stockfish {
 
 namespace Stockfish::Eval::NNUE::Features {
 
-  // Feature HalfKP: Combination of the position of own king
-  // and the position of pieces other than kings
-  class HalfKPChess {
+  // Feature HalfKAv2: Combination of the position of own king
+  // and the position of pieces
+  class HalfKAv2Variants {
 
     // unique number for each piece type on each square
     enum {
       PS_NONE     =  0,
-      PS_W_PAWN   =  1,
-      PS_B_PAWN   =  1 * SQUARE_NB_CHESS + 1,
-      PS_W_KNIGHT =  2 * SQUARE_NB_CHESS + 1,
-      PS_B_KNIGHT =  3 * SQUARE_NB_CHESS + 1,
-      PS_W_BISHOP =  4 * SQUARE_NB_CHESS + 1,
-      PS_B_BISHOP =  5 * SQUARE_NB_CHESS + 1,
-      PS_W_ROOK   =  6 * SQUARE_NB_CHESS + 1,
-      PS_B_ROOK   =  7 * SQUARE_NB_CHESS + 1,
-      PS_W_QUEEN  =  8 * SQUARE_NB_CHESS + 1,
-      PS_B_QUEEN  =  9 * SQUARE_NB_CHESS + 1,
-      PS_NB       = 10 * SQUARE_NB_CHESS + 1,
+      PS_W_PAWN   =  0,
+      PS_B_PAWN   =  1 * SQUARE_NB_CHESS,
+      PS_W_KNIGHT =  2 * SQUARE_NB_CHESS,
+      PS_B_KNIGHT =  3 * SQUARE_NB_CHESS,
+      PS_W_BISHOP =  4 * SQUARE_NB_CHESS,
+      PS_B_BISHOP =  5 * SQUARE_NB_CHESS,
+      PS_W_ROOK   =  6 * SQUARE_NB_CHESS,
+      PS_B_ROOK   =  7 * SQUARE_NB_CHESS,
+      PS_W_QUEEN  =  8 * SQUARE_NB_CHESS,
+      PS_B_QUEEN  =  9 * SQUARE_NB_CHESS,
+      PS_KING     =  10 * SQUARE_NB_CHESS,
+      PS_NB = 11 * SQUARE_NB_CHESS
     };
 
     static constexpr uint32_t PieceSquareIndex[COLOR_NB][PIECE_NB] = {
@@ -63,7 +67,7 @@ namespace Stockfish::Eval::NNUE::Features {
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
-        PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
+        PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_KING,
 
         PS_NONE, PS_B_PAWN, PS_B_KNIGHT, PS_B_BISHOP, PS_B_ROOK, PS_B_QUEEN, PS_B_QUEEN, PS_B_BISHOP,
         PS_B_BISHOP, PS_B_BISHOP, PS_B_QUEEN, PS_B_QUEEN, PS_NONE, PS_NONE, PS_B_QUEEN, PS_B_KNIGHT,
@@ -72,7 +76,7 @@ namespace Stockfish::Eval::NNUE::Features {
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
-        PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
+        PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_KING,
       },
 
       {
@@ -83,7 +87,7 @@ namespace Stockfish::Eval::NNUE::Features {
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
-        PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
+        PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_KING,
 
         PS_NONE, PS_W_PAWN, PS_W_KNIGHT, PS_W_BISHOP, PS_W_ROOK, PS_W_QUEEN, PS_W_QUEEN, PS_W_BISHOP,
         PS_W_BISHOP, PS_W_BISHOP, PS_W_QUEEN, PS_W_QUEEN, PS_NONE, PS_NONE, PS_W_QUEEN, PS_W_KNIGHT,
@@ -92,35 +96,44 @@ namespace Stockfish::Eval::NNUE::Features {
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
         PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
-        PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE,
+        PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_NONE, PS_KING,
       }
     };
     // Check that the fragile array definition is correct
     static_assert(PieceSquareIndex[WHITE][make_piece(WHITE, PAWN)] == PS_W_PAWN);
-    static_assert(PieceSquareIndex[WHITE][make_piece(WHITE, KING)] == PS_NONE);
+    static_assert(PieceSquareIndex[WHITE][make_piece(WHITE, KING)] == PS_KING);
     static_assert(PieceSquareIndex[WHITE][make_piece(BLACK, PAWN)] == PS_B_PAWN);
-    static_assert(PieceSquareIndex[WHITE][make_piece(BLACK, KING)] == PS_NONE);
-
+    static_assert(PieceSquareIndex[WHITE][make_piece(BLACK, KING)] == PS_KING);
 
     // Orient a square according to perspective (rotates by 180 for black)
-    static Square orient(Color perspective, Square s);
+    static Square orient(Color perspective, Square s, const Position& pos);
 
     // Index of a feature for a given king position and another piece on some square
-    static IndexType make_index(Color perspective, Square s, Piece pc, Square ksq);
+    static IndexType make_index(Color perspective, Square s, Piece pc, Square ksq, const Position& pos);
 
    public:
     // Feature name
-    static constexpr const char* Name = "HalfKP(Friend)";
+    static constexpr const char* Name = "HalfKAv2(Friend)";
 
     // Hash value embedded in the evaluation file
-    static constexpr std::uint32_t HashValue = 0x5D69D5B8u;
+    static constexpr std::uint32_t HashValue = 0x5f234cb8u;
 
     // Number of feature dimensions
     static constexpr IndexType Dimensions =
-        static_cast<IndexType>(SQUARE_NB_CHESS) * static_cast<IndexType>(PS_NB);
+#ifdef LARGEBOARDS
+        HalfKAv2Shogi::Dimensions;
+#else
+        HalfKAv2::Dimensions;
+#endif
 
-    // Maximum number of simultaneously active features. 30 because kins are not included.
-    static constexpr IndexType MaxActiveDimensions = 30;
+    static IndexType get_dimensions() {
+      return  currentNnueFeatures == NNUE_SHOGI ? HalfKAv2Shogi::Dimensions
+            : currentNnueFeatures == NNUE_CHESS ? HalfKAv2::Dimensions
+                                                : SQUARE_NB_CHESS * PS_NB;
+    }
+
+    // Maximum number of simultaneously active features.
+    static constexpr IndexType MaxActiveDimensions = 64;
 
     // Get a list of indices for active features
     static void append_active_indices(
@@ -149,4 +162,4 @@ namespace Stockfish::Eval::NNUE::Features {
 
 }  // namespace Stockfish::Eval::NNUE::Features
 
-#endif // #ifndef NNUE_FEATURES_HALF_KP_H_INCLUDED
+#endif // #ifndef NNUE_FEATURES_HALF_KA_V2_VARIANTS_H_INCLUDED

--- a/src/nnue/layers/clipped_relu.h
+++ b/src/nnue/layers/clipped_relu.h
@@ -72,22 +72,42 @@ namespace Stockfish::Eval::NNUE::Layers {
       const auto output = reinterpret_cast<OutputType*>(buffer);
 
   #if defined(USE_AVX2)
-      constexpr IndexType NumChunks = InputDimensions / SimdWidth;
-      const __m256i Zero = _mm256_setzero_si256();
-      const __m256i Offsets = _mm256_set_epi32(7, 3, 6, 2, 5, 1, 4, 0);
-      const auto in = reinterpret_cast<const __m256i*>(input);
-      const auto out = reinterpret_cast<__m256i*>(output);
-      for (IndexType i = 0; i < NumChunks; ++i) {
-        const __m256i words0 = _mm256_srai_epi16(_mm256_packs_epi32(
-            _mm256_load_si256(&in[i * 4 + 0]),
-            _mm256_load_si256(&in[i * 4 + 1])), WeightScaleBits);
-        const __m256i words1 = _mm256_srai_epi16(_mm256_packs_epi32(
-            _mm256_load_si256(&in[i * 4 + 2]),
-            _mm256_load_si256(&in[i * 4 + 3])), WeightScaleBits);
-        _mm256_store_si256(&out[i], _mm256_permutevar8x32_epi32(_mm256_max_epi8(
-            _mm256_packs_epi16(words0, words1), Zero), Offsets));
+      if constexpr (InputDimensions % SimdWidth == 0) {
+        constexpr IndexType NumChunks = InputDimensions / SimdWidth;
+        const __m256i Zero = _mm256_setzero_si256();
+        const __m256i Offsets = _mm256_set_epi32(7, 3, 6, 2, 5, 1, 4, 0);
+        const auto in = reinterpret_cast<const __m256i*>(input);
+        const auto out = reinterpret_cast<__m256i*>(output);
+        for (IndexType i = 0; i < NumChunks; ++i) {
+          const __m256i words0 = _mm256_srai_epi16(_mm256_packs_epi32(
+              _mm256_load_si256(&in[i * 4 + 0]),
+              _mm256_load_si256(&in[i * 4 + 1])), WeightScaleBits);
+          const __m256i words1 = _mm256_srai_epi16(_mm256_packs_epi32(
+              _mm256_load_si256(&in[i * 4 + 2]),
+              _mm256_load_si256(&in[i * 4 + 3])), WeightScaleBits);
+          _mm256_store_si256(&out[i], _mm256_permutevar8x32_epi32(_mm256_max_epi8(
+              _mm256_packs_epi16(words0, words1), Zero), Offsets));
+        }
+      } else {
+        constexpr IndexType NumChunks = InputDimensions / (SimdWidth / 2);
+        const __m128i Zero = _mm_setzero_si128();
+        const auto in = reinterpret_cast<const __m128i*>(input);
+        const auto out = reinterpret_cast<__m128i*>(output);
+        for (IndexType i = 0; i < NumChunks; ++i) {
+          const __m128i words0 = _mm_srai_epi16(_mm_packs_epi32(
+              _mm_load_si128(&in[i * 4 + 0]),
+              _mm_load_si128(&in[i * 4 + 1])), WeightScaleBits);
+          const __m128i words1 = _mm_srai_epi16(_mm_packs_epi32(
+              _mm_load_si128(&in[i * 4 + 2]),
+              _mm_load_si128(&in[i * 4 + 3])), WeightScaleBits);
+          const __m128i packedbytes = _mm_packs_epi16(words0, words1);
+          _mm_store_si128(&out[i], _mm_max_epi8(packedbytes, Zero));
+        }
       }
-      constexpr IndexType Start = NumChunks * SimdWidth;
+      constexpr IndexType Start =
+        InputDimensions % SimdWidth == 0
+        ? InputDimensions / SimdWidth * SimdWidth
+        : InputDimensions / (SimdWidth / 2) * (SimdWidth / 2);
 
   #elif defined(USE_SSE2)
       constexpr IndexType NumChunks = InputDimensions / SimdWidth;

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -30,8 +30,8 @@ namespace Stockfish::Eval::NNUE {
 
   // Class that holds the result of affine transformation of input features
   struct alignas(CacheLineSize) Accumulator {
-    std::int16_t
-        accumulation[2][TransformedFeatureDimensions];
+    std::int16_t accumulation[2][TransformedFeatureDimensions];
+    std::int32_t psqtAccumulation[2][PSQTBuckets];
     AccumulatorState state[2];
   };
 

--- a/src/nnue/nnue_architecture.h
+++ b/src/nnue/nnue_architecture.h
@@ -23,8 +23,7 @@
 
 #include "nnue_common.h"
 
-//#include "features/half_kp.h"
-#include "features/half_kp_variants.h"
+#include "features/half_ka_v2_variants.h"
 
 #include "layers/input_slice.h"
 #include "layers/affine_transform.h"
@@ -33,17 +32,18 @@
 namespace Stockfish::Eval::NNUE {
 
   // Input features used in evaluation function
-  //using FeatureSet = Features::HalfKPChess;
-  using FeatureSet = Features::HalfKPVariants;
+  using FeatureSet = Features::HalfKAv2Variants;
 
   // Number of input feature dimensions after conversion
-  constexpr IndexType TransformedFeatureDimensions = 256;
+  constexpr IndexType TransformedFeatureDimensions = 512;
+  constexpr IndexType PSQTBuckets = 8;
+  constexpr IndexType LayerStacks = 8;
 
   namespace Layers {
 
     // Define network structure
     using InputLayer = InputSlice<TransformedFeatureDimensions * 2>;
-    using HiddenLayer1 = ClippedReLU<AffineTransform<InputLayer, 32>>;
+    using HiddenLayer1 = ClippedReLU<AffineTransform<InputLayer, 16>>;
     using HiddenLayer2 = ClippedReLU<AffineTransform<HiddenLayer1, 32>>;
     using OutputLayer = AffineTransform<HiddenLayer2, 1>;
 

--- a/src/nnue/nnue_common.h
+++ b/src/nnue/nnue_common.h
@@ -46,7 +46,7 @@
 namespace Stockfish::Eval::NNUE {
 
   // Version of the evaluation file
-  constexpr std::uint32_t Version = 0x7AF32F16u;
+  constexpr std::uint32_t Version = 0x7AF32F20u;
 
   // Constant used in evaluation value calculation
   constexpr int OutputScale = 16;

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -35,45 +35,82 @@ namespace Stockfish::Eval::NNUE {
   // vector registers.
   #define VECTOR
 
+  static_assert(PSQTBuckets == 8, "Assumed by the current choice of constants.");
+
   #ifdef USE_AVX512
   typedef __m512i vec_t;
+  typedef __m256i psqt_vec_t;
   #define vec_load(a) _mm512_load_si512(a)
   #define vec_store(a,b) _mm512_store_si512(a,b)
   #define vec_add_16(a,b) _mm512_add_epi16(a,b)
   #define vec_sub_16(a,b) _mm512_sub_epi16(a,b)
+  #define vec_load_psqt(a) _mm256_load_si256(a)
+  #define vec_store_psqt(a,b) _mm256_store_si256(a,b)
+  #define vec_add_psqt_32(a,b) _mm256_add_epi32(a,b)
+  #define vec_sub_psqt_32(a,b) _mm256_sub_epi32(a,b)
+  #define vec_zero_psqt() _mm256_setzero_si256()
   static constexpr IndexType NumRegs = 8; // only 8 are needed
+  static constexpr IndexType NumPsqtRegs = 1;
 
   #elif USE_AVX2
   typedef __m256i vec_t;
+  typedef __m256i psqt_vec_t;
   #define vec_load(a) _mm256_load_si256(a)
   #define vec_store(a,b) _mm256_store_si256(a,b)
   #define vec_add_16(a,b) _mm256_add_epi16(a,b)
   #define vec_sub_16(a,b) _mm256_sub_epi16(a,b)
+  #define vec_load_psqt(a) _mm256_load_si256(a)
+  #define vec_store_psqt(a,b) _mm256_store_si256(a,b)
+  #define vec_add_psqt_32(a,b) _mm256_add_epi32(a,b)
+  #define vec_sub_psqt_32(a,b) _mm256_sub_epi32(a,b)
+  #define vec_zero_psqt() _mm256_setzero_si256()
   static constexpr IndexType NumRegs = 16;
+  static constexpr IndexType NumPsqtRegs = 1;
 
   #elif USE_SSE2
   typedef __m128i vec_t;
+  typedef __m128i psqt_vec_t;
   #define vec_load(a) (*(a))
   #define vec_store(a,b) *(a)=(b)
   #define vec_add_16(a,b) _mm_add_epi16(a,b)
   #define vec_sub_16(a,b) _mm_sub_epi16(a,b)
+  #define vec_load_psqt(a) (*(a))
+  #define vec_store_psqt(a,b) *(a)=(b)
+  #define vec_add_psqt_32(a,b) _mm_add_epi32(a,b)
+  #define vec_sub_psqt_32(a,b) _mm_sub_epi32(a,b)
+  #define vec_zero_psqt() _mm_setzero_si128()
   static constexpr IndexType NumRegs = Is64Bit ? 16 : 8;
+  static constexpr IndexType NumPsqtRegs = 2;
 
   #elif USE_MMX
   typedef __m64 vec_t;
+  typedef std::int32_t psqt_vec_t;
   #define vec_load(a) (*(a))
   #define vec_store(a,b) *(a)=(b)
   #define vec_add_16(a,b) _mm_add_pi16(a,b)
   #define vec_sub_16(a,b) _mm_sub_pi16(a,b)
+  #define vec_load_psqt(a) (*(a))
+  #define vec_store_psqt(a,b) *(a)=(b)
+  #define vec_add_psqt_32(a,b) a+b
+  #define vec_sub_psqt_32(a,b) a-b
+  #define vec_zero_psqt() 0
   static constexpr IndexType NumRegs = 8;
+  static constexpr IndexType NumPsqtRegs = 8;
 
   #elif USE_NEON
   typedef int16x8_t vec_t;
+  typedef int32x4_t psqt_vec_t;
   #define vec_load(a) (*(a))
   #define vec_store(a,b) *(a)=(b)
   #define vec_add_16(a,b) vaddq_s16(a,b)
   #define vec_sub_16(a,b) vsubq_s16(a,b)
+  #define vec_load_psqt(a) (*(a))
+  #define vec_store_psqt(a,b) *(a)=(b)
+  #define vec_add_psqt_32(a,b) vaddq_s32(a,b)
+  #define vec_sub_psqt_32(a,b) vsubq_s32(a,b)
+  #define vec_zero_psqt() psqt_vec_t{0}
   static constexpr IndexType NumRegs = 16;
+  static constexpr IndexType NumPsqtRegs = 2;
 
   #else
   #undef VECTOR
@@ -87,9 +124,13 @@ namespace Stockfish::Eval::NNUE {
     // Number of output dimensions for one side
     static constexpr IndexType HalfDimensions = TransformedFeatureDimensions;
 
+    static constexpr int LazyThreshold = 14000; // low lazy threshold is detrimental for variants
+
     #ifdef VECTOR
     static constexpr IndexType TileHeight = NumRegs * sizeof(vec_t) / 2;
+    static constexpr IndexType PsqtTileHeight = NumPsqtRegs * sizeof(psqt_vec_t) / 4;
     static_assert(HalfDimensions % TileHeight == 0, "TileHeight must divide HalfDimensions");
+    static_assert(PSQTBuckets % PsqtTileHeight == 0, "PsqtTileHeight must divide PSQTBuckets");
     #endif
 
    public:
@@ -116,6 +157,8 @@ namespace Stockfish::Eval::NNUE {
         biases[i] = read_little_endian<BiasType>(stream);
       for (std::size_t i = 0; i < HalfDimensions * FeatureSet::get_dimensions(); ++i)
         weights[i] = read_little_endian<WeightType>(stream);
+      for (std::size_t i = 0; i < PSQTBuckets * FeatureSet::get_dimensions(); ++i)
+        psqtWeights[i] = read_little_endian<PSQTWeightType>(stream);
       return !stream.fail();
     }
 
@@ -123,17 +166,27 @@ namespace Stockfish::Eval::NNUE {
     bool write_parameters(std::ostream& stream) const {
       for (std::size_t i = 0; i < HalfDimensions; ++i)
         write_little_endian<BiasType>(stream, biases[i]);
-      for (std::size_t i = 0; i < HalfDimensions * InputDimensions; ++i)
+      for (std::size_t i = 0; i < HalfDimensions * FeatureSet::get_dimensions(); ++i)
         write_little_endian<WeightType>(stream, weights[i]);
       return !stream.fail();
     }
 
     // Convert input features
-    void transform(const Position& pos, OutputType* output) const {
+    std::pair<std::int32_t, bool> transform(const Position& pos, OutputType* output, int bucket) const {
       update_accumulator(pos, WHITE);
       update_accumulator(pos, BLACK);
 
+      const Color perspectives[2] = {pos.side_to_move(), ~pos.side_to_move()};
       const auto& accumulation = pos.state()->accumulator.accumulation;
+      const auto& psqtAccumulation = pos.state()->accumulator.psqtAccumulation;
+
+      const auto psqt = (
+            psqtAccumulation[static_cast<int>(perspectives[0])][bucket]
+          - psqtAccumulation[static_cast<int>(perspectives[1])][bucket]
+        ) / 2;
+
+      if (abs(psqt) > LazyThreshold * OutputScale)
+        return { psqt, true };
 
   #if defined(USE_AVX512)
       constexpr IndexType NumChunks = HalfDimensions / (SimdWidth * 2);
@@ -164,7 +217,6 @@ namespace Stockfish::Eval::NNUE {
       const int8x8_t Zero = {0};
   #endif
 
-      const Color perspectives[2] = {pos.side_to_move(), ~pos.side_to_move()};
       for (IndexType p = 0; p < 2; ++p) {
         const IndexType offset = HalfDimensions * p;
 
@@ -241,6 +293,8 @@ namespace Stockfish::Eval::NNUE {
   #if defined(USE_MMX)
       _mm_empty();
   #endif
+
+      return { psqt, false };
     }
 
    private:
@@ -256,6 +310,7 @@ namespace Stockfish::Eval::NNUE {
       // Gcc-10.2 unnecessarily spills AVX2 registers if this array
       // is defined in the VECTOR code below, once in each branch
       vec_t acc[NumRegs];
+      psqt_vec_t psqt[NumPsqtRegs];
   #endif
 
       // Look for a usable accumulator of an earlier position. We keep track
@@ -334,12 +389,52 @@ namespace Stockfish::Eval::NNUE {
           }
         }
 
+        for (IndexType j = 0; j < PSQTBuckets / PsqtTileHeight; ++j)
+        {
+          // Load accumulator
+          auto accTilePsqt = reinterpret_cast<psqt_vec_t*>(
+            &st->accumulator.psqtAccumulation[perspective][j * PsqtTileHeight]);
+          for (std::size_t k = 0; k < NumPsqtRegs; ++k)
+            psqt[k] = vec_load_psqt(&accTilePsqt[k]);
+
+          for (IndexType i = 0; states_to_update[i]; ++i)
+          {
+            // Difference calculation for the deactivated features
+            for (const auto index : removed[i])
+            {
+              const IndexType offset = PSQTBuckets * index + j * PsqtTileHeight;
+              auto columnPsqt = reinterpret_cast<const psqt_vec_t*>(&psqtWeights[offset]);
+              for (std::size_t k = 0; k < NumPsqtRegs; ++k)
+                psqt[k] = vec_sub_psqt_32(psqt[k], columnPsqt[k]);
+            }
+
+            // Difference calculation for the activated features
+            for (const auto index : added[i])
+            {
+              const IndexType offset = PSQTBuckets * index + j * PsqtTileHeight;
+              auto columnPsqt = reinterpret_cast<const psqt_vec_t*>(&psqtWeights[offset]);
+              for (std::size_t k = 0; k < NumPsqtRegs; ++k)
+                psqt[k] = vec_add_psqt_32(psqt[k], columnPsqt[k]);
+            }
+
+            // Store accumulator
+            accTilePsqt = reinterpret_cast<psqt_vec_t*>(
+              &states_to_update[i]->accumulator.psqtAccumulation[perspective][j * PsqtTileHeight]);
+            for (std::size_t k = 0; k < NumPsqtRegs; ++k)
+              vec_store_psqt(&accTilePsqt[k], psqt[k]);
+          }
+        }
+
   #else
         for (IndexType i = 0; states_to_update[i]; ++i)
         {
           std::memcpy(states_to_update[i]->accumulator.accumulation[perspective],
               st->accumulator.accumulation[perspective],
               HalfDimensions * sizeof(BiasType));
+
+          for (std::size_t k = 0; k < PSQTBuckets; ++k)
+            states_to_update[i]->accumulator.psqtAccumulation[perspective][k] = st->accumulator.psqtAccumulation[perspective][k];
+
           st = states_to_update[i];
 
           // Difference calculation for the deactivated features
@@ -349,6 +444,9 @@ namespace Stockfish::Eval::NNUE {
 
             for (IndexType j = 0; j < HalfDimensions; ++j)
               st->accumulator.accumulation[perspective][j] -= weights[offset + j];
+
+            for (std::size_t k = 0; k < PSQTBuckets; ++k)
+              st->accumulator.psqtAccumulation[perspective][k] -= psqtWeights[index * PSQTBuckets + k];
           }
 
           // Difference calculation for the activated features
@@ -358,6 +456,9 @@ namespace Stockfish::Eval::NNUE {
 
             for (IndexType j = 0; j < HalfDimensions; ++j)
               st->accumulator.accumulation[perspective][j] += weights[offset + j];
+
+            for (std::size_t k = 0; k < PSQTBuckets; ++k)
+              st->accumulator.psqtAccumulation[perspective][k] += psqtWeights[index * PSQTBuckets + k];
           }
         }
   #endif
@@ -393,9 +494,32 @@ namespace Stockfish::Eval::NNUE {
             vec_store(&accTile[k], acc[k]);
         }
 
+        for (IndexType j = 0; j < PSQTBuckets / PsqtTileHeight; ++j)
+        {
+          for (std::size_t k = 0; k < NumPsqtRegs; ++k)
+            psqt[k] = vec_zero_psqt();
+
+          for (const auto index : active)
+          {
+            const IndexType offset = PSQTBuckets * index + j * PsqtTileHeight;
+            auto columnPsqt = reinterpret_cast<const psqt_vec_t*>(&psqtWeights[offset]);
+
+            for (std::size_t k = 0; k < NumPsqtRegs; ++k)
+              psqt[k] = vec_add_psqt_32(psqt[k], columnPsqt[k]);
+          }
+
+          auto accTilePsqt = reinterpret_cast<psqt_vec_t*>(
+            &accumulator.psqtAccumulation[perspective][j * PsqtTileHeight]);
+          for (std::size_t k = 0; k < NumPsqtRegs; ++k)
+            vec_store_psqt(&accTilePsqt[k], psqt[k]);
+        }
+
   #else
         std::memcpy(accumulator.accumulation[perspective], biases,
             HalfDimensions * sizeof(BiasType));
+
+        for (std::size_t k = 0; k < PSQTBuckets; ++k)
+          accumulator.psqtAccumulation[perspective][k] = 0;
 
         for (const auto index : active)
         {
@@ -403,6 +527,9 @@ namespace Stockfish::Eval::NNUE {
 
           for (IndexType j = 0; j < HalfDimensions; ++j)
             accumulator.accumulation[perspective][j] += weights[offset + j];
+
+          for (std::size_t k = 0; k < PSQTBuckets; ++k)
+            accumulator.psqtAccumulation[perspective][k] += psqtWeights[index * PSQTBuckets + k];
         }
   #endif
       }
@@ -414,9 +541,11 @@ namespace Stockfish::Eval::NNUE {
 
     using BiasType = std::int16_t;
     using WeightType = std::int16_t;
+    using PSQTWeightType = std::int32_t;
 
     alignas(CacheLineSize) BiasType biases[HalfDimensions];
     alignas(CacheLineSize) WeightType weights[HalfDimensions * InputDimensions];
+    alignas(CacheLineSize) PSQTWeightType psqtWeights[InputDimensions * PSQTBuckets];
   };
 
 }  // namespace Stockfish::Eval::NNUE

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -68,7 +68,7 @@ namespace {
 
   // Futility margin
   Value futility_margin(Depth d, bool improving) {
-    return Value(234 * (d - improving));
+    return Value(231 * (d - improving));
   }
 
   // Reductions lookup table, initialized at startup
@@ -937,7 +937,7 @@ namespace {
         && (ss-1)->statScore < 24185
         &&  eval >= beta
         &&  eval >= ss->staticEval
-        &&  ss->staticEval >= beta - 24 * depth - 34 * improving + 162 * ss->ttPv + 159 + 200 * (!pos.double_step_enabled() && pos.piece_to_char()[PAWN] != ' ')
+        &&  ss->staticEval >= beta - 22 * depth - 34 * improving + 162 * ss->ttPv + 159 + 200 * (!pos.double_step_enabled() && pos.piece_to_char()[PAWN] != ' ')
         && !excludedMove
         &&  pos.non_pawn_material(us)
         &&  pos.count<ALL_PIECES>(~us) != pos.count<PAWN>(~us)
@@ -1320,7 +1320,7 @@ moves_loop: // When in check, search starts from here
                              + (*contHist[0])[history_slot(movedPiece)][to_sq(move)]
                              + (*contHist[1])[history_slot(movedPiece)][to_sq(move)]
                              + (*contHist[3])[history_slot(movedPiece)][to_sq(move)]
-                             - 4741;
+                             - 4791;
 
               // Decrease/increase reduction for moves with a good/bad history (~30 Elo)
               if (!ss->inCheck)


### PR DESCRIPTION
* Requires to train corresponding variant nets to not lose NNUE support for variants where HalfKP nets already are available.
* Disable NNUE lazy eval for variants?