### PR TITLE
Updated ffish.js to 0.6.2

### DIFF
--- a/tests/js/package.json
+++ b/tests/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffish",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "A high performance WebAssembly chess variant library based on Fairy-Stockfish",
   "main": "ffish.js",
   "scripts": {


### PR DESCRIPTION
As suggested in  Fix variant initialization for libraries.
* https://github.com/ianfab/Fairy-Stockfish/commit/78700852f96db30149f1105f80364d092d12d90f

This PR only changes the version id.
New libraries are already published on npm:
* https://www.npmjs.com/package/ffish