### PR TITLE
Fixed blasted pieces incorrectly updating key's castling rights

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1770,9 +1770,9 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
           // Update castling rights if needed
           if (st->castlingRights && castlingRightsMask[bsq])
           {
-              int cr = castlingRightsMask[bsq];
-              k ^= Zobrist::castling[st->castlingRights & cr];
-              st->castlingRights &= ~cr;
+             k ^= Zobrist::castling[st->castlingRights];
+             st->castlingRights &= ~castlingRightsMask[bsq];
+             k ^= Zobrist::castling[st->castlingRights];
           }
       }
   }


### PR DESCRIPTION
This fixes a bug with how blasting in atomic affects castling rights' keys.

reproduction:
turn off Fast in `pos_is_ok`
run in debug:
```
xboard
variant atomic
setboard 7k/8/8/7q/8/8/7P/4K2R b K - 0 1
usermove h5h2
```
the key will differ when recalculated