### PR TITLE
Generalize incremental computation for hand pieces

### DIFF
--- a/src/nnue/features/half_ka_v2_variants.cpp
+++ b/src/nnue/features/half_ka_v2_variants.cpp
@@ -84,11 +84,11 @@ namespace Stockfish::Eval::NNUE::Features {
       Piece pc = dp.piece[i];
       if (dp.from[i] != SQ_NONE)
         removed.push_back(make_index(perspective, dp.from[i], pc, oriented_ksq, pos));
-      else if (pos.piece_drops() && dp.dirty_num == 1)
+      else if (dp.handPiece[i] != NO_PIECE)
         removed.push_back(make_index(perspective, dp.handCount[i], dp.handPiece[i], oriented_ksq, pos));
       if (dp.to[i] != SQ_NONE)
         added.push_back(make_index(perspective, dp.to[i], pc, oriented_ksq, pos));
-      else if (pos.captures_to_hand() && i == 1)
+      else if (dp.handPiece[i] != NO_PIECE)
         added.push_back(make_index(perspective, dp.handCount[i] - 1, dp.handPiece[i], oriented_ksq, pos));
     }
   }

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1434,7 +1434,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
               dp.handCount[1] = pieceCountInHand[color_of(pieceToHand)][type_of(pieceToHand)];
           }
       }
-      else
+      else if (Eval::useNNUE)
           dp.handPiece[1] = NO_PIECE;
 
       // Update material hash key and prefetch access to materialTable
@@ -1591,6 +1591,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
           {
               // Promoting pawn to SQ_NONE, promoted piece from SQ_NONE
               dp.to[0] = SQ_NONE;
+              dp.handPiece[0] = NO_PIECE;
               dp.piece[dp.dirty_num] = promotion;
               dp.handPiece[dp.dirty_num] = NO_PIECE;
               dp.from[dp.dirty_num] = SQ_NONE;
@@ -1625,6 +1626,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
       {
           // Promoting piece to SQ_NONE, promoted piece from SQ_NONE
           dp.to[0] = SQ_NONE;
+          dp.handPiece[0] = NO_PIECE;
           dp.piece[dp.dirty_num] = promotion;
           dp.handPiece[dp.dirty_num] = NO_PIECE;
           dp.from[dp.dirty_num] = SQ_NONE;
@@ -1651,6 +1653,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
       {
           // Demoting piece to SQ_NONE, demoted piece from SQ_NONE
           dp.to[0] = SQ_NONE;
+          dp.handPiece[0] = NO_PIECE;
           dp.piece[dp.dirty_num] = demotion;
           dp.handPiece[dp.dirty_num] = NO_PIECE;
           dp.from[dp.dirty_num] = SQ_NONE;


### PR DESCRIPTION
This allows to apply incremental NNUE computation not only to drop variants,
but also to S-Chess gating and drop variants with blast captures.