### PR TITLE
Autoload variants.ini if specified in by an environment variable

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -16,6 +16,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <cstdlib>
 #include <cassert>
 #include <cmath>
 #include <iostream>
@@ -286,6 +287,11 @@ void UCI::loop(int argc, char* argv[]) {
   XBoard::stateMachine = new XBoard::StateMachine(pos, states);
   // UCCI banmoves state
   std::vector<Move> banmoves = {};
+
+  // Check environment for variants.ini file
+  char *envVariantPath = std::getenv("FAIRY_STOCKFISH_VARIANT_PATH");
+  if (envVariantPath != NULL)
+      Options["VariantPath"] = std::string(envVariantPath);
 
   do {
       if (argc == 1 && !getline(cin, cmd)) // Block here waiting for input or EOF

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -288,7 +288,12 @@ void UCI::loop(int argc, char* argv[]) {
   // UCCI banmoves state
   std::vector<Move> banmoves = {};
 
-  if (argc == 1)
+  if (argc > 1 && (std::strcmp(argv[1], "noautoload") == 0))
+  {
+      cmd = "";
+      argc = 1;
+  }
+  else if (argc == 1 || !(std::strcmp(argv[1], "load") == 0))
   {
       // Check environment for variants.ini file
       char *envVariantPath = std::getenv("FAIRY_STOCKFISH_VARIANT_PATH");

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -288,10 +288,13 @@ void UCI::loop(int argc, char* argv[]) {
   // UCCI banmoves state
   std::vector<Move> banmoves = {};
 
-  // Check environment for variants.ini file
-  char *envVariantPath = std::getenv("FAIRY_STOCKFISH_VARIANT_PATH");
-  if (envVariantPath != NULL)
-      Options["VariantPath"] = std::string(envVariantPath);
+  if (argc == 1)
+  {
+      // Check environment for variants.ini file
+      char *envVariantPath = std::getenv("FAIRY_STOCKFISH_VARIANT_PATH");
+      if (envVariantPath != NULL)
+          Options["VariantPath"] = std::string(envVariantPath);
+  }
 
   do {
       if (argc == 1 && !getline(cin, cmd)) // Block here waiting for input or EOF


### PR DESCRIPTION
Hi, thanks for making Fairy-Stockfish! I've been enjoying using it.

I'm just making this pull request to put this out there if anyone is interested. I've been messing around with custom variants, and think it would be convenient to not need to specify the load command if you keep your variants file in the same place. This PR will have Fairy-Stockfish check the environment variant `FAIRY_STOCKFISH_VARIANT_PATH`, and if it exists, it will load the file at this path as the variant config. This will get overridden by a "load" command on the command line.

I tested it on Windows 10 and Linux Mint 20.2, and it works pretty well!

I have a question though, and maybe it should go in an issue. I noticed that the "load" command, when entered as a command line arg or in the UCI loop, cannot handle paths with spaces in it. So, on Windows if I try loading `C:\Program Files\fairy-stockfish\variants.ini`, it would try and fail to load two files `C:\Program` and `Files\fairy-stockfish\variants.ini`. I'm not sure what we can do about this since users might want to load multiple files in one load command, maybe we could escape strings? Seems to add unneeded complexity ¯\\\_(ツ)\_/¯ Setting the "VariantPath" UCI option directly works though (both in code and in the UCI loop), so that's what I'm doing here.

Thanks for writing Fairy-Stockfish, and thanks for your time! :smile: