### PR TITLE
Expose additional game-end functions in ffish.js

### DIFF
--- a/src/ffishjs.cpp
+++ b/src/ffishjs.cpp
@@ -263,6 +263,34 @@ public:
     return pos.game_ply();
   }
 
+  int game_result() const {
+    Value result;
+    bool gameEnd;
+    if (MoveList<LEGAL>(pos).size() > 0)
+      return VALUE_NONE;
+    gameEnd = pos.is_immediate_game_end(result);
+    if (!gameEnd)
+        result = pos.checkers() ? pos.checkmate_value() : pos.stalemate_value();
+    return result;
+  }
+
+  bool is_immediate_game_end() const {
+    return pos.is_immediate_game_end();
+  }
+
+  bool is_optional_game_end() const {
+    return pos.is_optional_game_end();
+  }
+
+  // Need to use different name than has_insufficient_material
+  bool has_insufficient_material_ffish(bool turn) const {
+    return has_insufficient_material(turn ? WHITE : BLACK, pos);
+  }
+
+  bool has_insufficient_material_ffish() const {
+    return has_insufficient_material(WHITE, pos) && has_insufficient_material(BLACK, pos);
+  }
+
   bool is_game_over() const {
     for (const ExtMove& move: MoveList<LEGAL>(pos))
       return false;
@@ -626,6 +654,11 @@ EMSCRIPTEN_BINDINGS(ffish_js) {
     .function("fullmoveNumber", &Board::fullmove_number)
     .function("halfmoveClock", &Board::halfmove_clock)
     .function("gamePly", &Board::game_ply)
+    .function("gameResult", &Board::game_result)
+    .function("isImmediateGameEnd", &Board::is_immediate_game_end)
+    .function("isOptionalGameEnd", &Board::is_optional_game_end)
+    .function("hasInsufficientMaterial", select_overload<bool(bool) const>(&Board::has_insufficient_material_ffish))
+    .function("hasInsufficientMaterial", select_overload<bool() const>(&Board::has_insufficient_material_ffish))
     .function("isGameOver", &Board::is_game_over)
     .function("isCheck", &Board::is_check)
     .function("isBikjang", &Board::is_bikjang)


### PR DESCRIPTION
In pyffish, there are functions exposed to check for insufficient material, optional draws (50 move, threefold, etc), and to get the resulting value of the game. Such functionality didn't exist in ffish.js, and I wanted it exposed so I could mess around with it in [my toy ffish.js+chessboardx project](https://github.com/thearst3rd/ffish-test) I've been working on lately.

There are some things I'm not sure I'm doing totally right - for example, `is_immediate_game_end` and `is_optional_game_end` have a parameter which can specify the value of the game (if the game did immediately or optionally end). Right now, I'm only returning a boolean of whether or not the game ended. Maybe it would be nice if we could return a javascript array such that the first item is the boolean, and the second item (if the first is true) will be the value? I'm not very familiar with emscripten but I'm hoping something like that will be possible.

I still have some questions, such as it seems that no game end function automatically considers insufficient material (for example, it is totally ignored on pychess.org analysis boards) but I think these functions match up pretty well with the pyffish versions so I'm assuming that's ok.

I've been really enjoying using this library so far and I hope these functions may be useful!

CC: @QueensGambit 