### PR TITLE
Support spaces in variants.ini path

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -87,12 +87,7 @@ namespace Eval {
     stringstream ss(eval_file);
     string variant = string(Options["UCI_Variant"]);
     useNNUE = false;
-#ifndef _WIN32
-    constexpr char SepChar = ':';
-#else
-    constexpr char SepChar = ';';
-#endif
-    while (getline(ss, eval_file, SepChar))
+    while (getline(ss, eval_file, UCI::SepChar))
     {
         string basename = eval_file.substr(eval_file.find_last_of("\\/") + 1);
         string nnueAlias = variants.find(variant)->second->nnueAlias;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -248,18 +248,22 @@ namespace {
   void load(istringstream& is) {
 
     string token;
-    while (is >> token)
-        Options["VariantPath"] = token;
+    std::getline(is >> std::ws, token);
+    std::size_t end = token.find_last_not_of(' ');
+    if (end != std::string::npos)
+        Options["VariantPath"] = token.erase(end + 1);
   }
 
   // check() is called when engine receives the "check" command.
-  // The function reads variant configuration files and validates them.
+  // The function reads a variant configuration file and validates it.
 
   void check(istringstream& is) {
 
     string token;
-    while (is >> token)
-        variants.parse<true>(token);
+    std::getline(is >> std::ws, token);
+    std::size_t end = token.find_last_not_of(' ');
+    if (end != std::string::npos)
+        variants.parse<true>(token.erase(end + 1));
   }
 
 } // namespace

--- a/src/uci.h
+++ b/src/uci.h
@@ -33,6 +33,12 @@ class Position;
 
 namespace UCI {
 
+#ifndef _WIN32
+  constexpr char SepChar = ':';
+#else
+  constexpr char SepChar = ';';
+#endif
+
 void init_variant(const Variant* v);
 
 class Option;

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -66,7 +66,15 @@ void on_tb_path(const Option& o) { Tablebases::init(o); }
 void on_use_NNUE(const Option& ) { Eval::NNUE::init(); }
 void on_eval_file(const Option& ) { Eval::NNUE::init(); }
 
-void on_variant_path(const Option& o) { variants.parse<false>(o); Options["UCI_Variant"].set_combo(variants.get_keys()); }
+void on_variant_path(const Option& o) {
+    std::stringstream ss((std::string)o);
+    std::string path;
+
+    while (std::getline(ss, path, SepChar))
+        variants.parse<false>(path);
+
+    Options["UCI_Variant"].set_combo(variants.get_keys());
+}
 void on_variant_set(const Option &o) {
     // Re-initialize NNUE
     Eval::NNUE::init();


### PR DESCRIPTION
* Allow whitespace characters in `load` command.
* Support loading of multiple files separated by `:`/`;`.

Closes #361.