### PR TITLE
Support NNUE with varying king dimensions

### DIFF
--- a/src/nnue/features/half_ka_v2_variants.cpp
+++ b/src/nnue/features/half_ka_v2_variants.cpp
@@ -30,19 +30,20 @@ namespace Stockfish::Eval::NNUE::Features {
   }
 
   // Orient a square according to perspective (rotates by 180 for black)
+  // Missing kings map to index 0 (SQ_A1)
   inline Square HalfKAv2Variants::orient(Color perspective, Square s, const Position& pos) {
-    return to_variant_square(  perspective == WHITE || (pos.capture_the_flag(BLACK) & Rank8BB) ? s
-                             : flip_rank(s, pos.max_rank()), pos);
+    return s != SQ_NONE ? to_variant_square(  perspective == WHITE || (pos.capture_the_flag(BLACK) & Rank8BB) ? s
+                                            : flip_rank(s, pos.max_rank()), pos) : SQ_A1;
   }
 
   // Index of a feature for a given king position and another piece on some square
   inline IndexType HalfKAv2Variants::make_index(Color perspective, Square s, Piece pc, Square ksq, const Position& pos) {
-    return IndexType(orient(perspective, s, pos) + pos.variant()->pieceSquareIndex[perspective][pc] + ksq * pos.variant()->nnuePieceIndices);
+    return IndexType(orient(perspective, s, pos) + pos.variant()->pieceSquareIndex[perspective][pc] + pos.variant()->kingSquareIndex[ksq]);
   }
 
   // Index of a feature for a given king position and another piece on some square
   inline IndexType HalfKAv2Variants::make_index(Color perspective, int handCount, Piece pc, Square ksq, const Position& pos) {
-    return IndexType(handCount + pos.variant()->pieceHandIndex[perspective][pc] + ksq * pos.variant()->nnuePieceIndices);
+    return IndexType(handCount + pos.variant()->pieceHandIndex[perspective][pc] + pos.variant()->kingSquareIndex[ksq]);
   }
 
   // Get a list of indices for active features
@@ -51,7 +52,7 @@ namespace Stockfish::Eval::NNUE::Features {
     Color perspective,
     ValueListInserter<IndexType> active
   ) {
-    Square oriented_ksq = orient(perspective, pos.square(perspective, pos.nnue_king()), pos);
+    Square oriented_ksq = orient(perspective, pos.nnue_king_square(perspective), pos);
     Bitboard bb = pos.pieces();
     while (bb)
     {

--- a/src/nnue/features/half_ka_v2_variants.h
+++ b/src/nnue/features/half_ka_v2_variants.h
@@ -58,7 +58,7 @@ namespace Stockfish::Eval::NNUE::Features {
     static constexpr IndexType Dimensions = static_cast<IndexType>(SQUARE_NB) * static_cast<IndexType>(SQUARE_NB) * 19;
 
     static IndexType get_dimensions() {
-      return currentNnueVariant->nnueSquares * currentNnueVariant->nnuePieceIndices;
+      return currentNnueVariant->nnueDimensions;
     }
 
     // Maximum number of simultaneously active features.

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -403,7 +403,7 @@ namespace Stockfish::Eval::NNUE {
         // accumulator. Then, we update the current accumulator (pos.state()).
 
         // Gather all features to be updated.
-        const Square ksq = pos.square(perspective, pos.nnue_king());
+        const Square ksq = pos.nnue_king_square(perspective);
         IndexList removed[2], added[2];
         FeatureSet::append_changed_indices(
           ksq, next, perspective, removed[0], added[0], pos);

--- a/src/position.h
+++ b/src/position.h
@@ -147,6 +147,7 @@ public:
   PieceType castling_rook_piece() const;
   PieceType king_type() const;
   PieceType nnue_king() const;
+  Square nnue_king_square(Color c) const;
   bool nnue_use_pockets() const;
   bool nnue_applicable() const;
   bool checking_permitted() const;
@@ -526,6 +527,10 @@ inline PieceType Position::king_type() const {
 inline PieceType Position::nnue_king() const {
   assert(var != nullptr);
   return var->nnueKing;
+}
+
+inline Square Position::nnue_king_square(Color c) const {
+  return nnue_king() ? square(c, nnue_king()) : SQ_NONE;
 }
 
 inline bool Position::nnue_use_pockets() const {


### PR DESCRIPTION
This adds dedicated NNUE support for variants where kings
only have access to a limited set of squares, like Xiangqi,
or are missing entirely, like in antichess.

Closes #346.