### PR TITLE
Bump ffish to 0.6.5

### DIFF
--- a/tests/js/package.json
+++ b/tests/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffish",
-  "version": "0.6.3",
+  "version": "0.6.5",
   "description": "A high performance WebAssembly chess variant library based on Fairy-Stockfish",
   "main": "ffish.js",
   "scripts": {


### PR DESCRIPTION
Bumped version to 0.6.5 as requested in https://github.com/ianfab/Fairy-Stockfish/issues/408.

Releases are available on **npm** using today's commit.
* https://www.npmjs.com/package/ffish