### PR TITLE
Fixed Pandemonium, added Parahouse (new variant)

### DIFF
--- a/src/variants.ini
+++ b/src/variants.ini
@@ -720,6 +720,9 @@ perpetualCheckIllegal = true
 nMoveRule = 0
 nFoldValue = loss
 stalemateValue = loss
+flagPiece = k
+whiteFlag = *9
+blackFlag = *1
 
 # 5x5 breakthrough
 [breakthrough5:breakthrough]
@@ -743,4 +746,43 @@ maxFile = 7
 maxRank = 7
 startFen = ppppppp/ppppppp/7/7/7/PPPPPPP/PPPPPPP w 0 1
 whiteFlag = *7
+blackFlag = *1
+
+# Shogi + Strong pieces
+[parahouse]
+variantTemplate = shogi
+pieceToCharTable = PNBR.Q.HD..++++.+.++Kpnbr.q.hd..++++.+.++k
+maxFile = 9
+maxRank = 9
+pocketSize = 7
+startFen = rnbdkhbnr/4q4/ppppppppp/9/9/9/PPPPPPPPP/4Q4/RNBHKDBNR[] w - - 0 1
+customPiece1 = a:QN
+customPiece2 = t:BNW
+customPiece3 = s:RNF
+castling = false
+capturesToHand = true
+pieceDrops = true
+dropNoDoubled = p
+immobilityIllegal = true
+shogiPawn = p
+knight = n
+bishop = b
+rook = r
+queen = q
+dragonHorse = h
+bers = d
+king = k
+commoner = g
+centaur = j
+archbishop = c
+chancellor = m
+promotionRank = 7
+promotedPieceType = p:g n:j b:c r:m q:a h:t d:s
+doubleStep = false
+perpetualCheckIllegal = true
+nMoveRule = 0
+nFoldValue = loss
+stalemateValue = loss
+flagPiece = k
+whiteFlag = *9
 blackFlag = *1


### PR DESCRIPTION
1. Addition of Campmate rules in Pandemonium

2. Addition of a new chess variant, Parahouse

I would like to ask you two things.

//

Regarding number 1,

[pandemonium]
variantTemplate = shogi
pieceToCharTable = PNBRFSA.UV.++++++++.++Kpnbrfsa.uv.++++++++.++k
maxFile = 9
maxRank = 9
pocketSize = 9
startFen = rnbsksbnr/2+f1+u1+a2/p1p1p1p1p/4v4/9/4V4/P1P1P1P1P/2+F1+U1+A2/RNBSKSBNR[] w - - 0 1
customPiece1 = o:NA
customPiece2 = s:WF
customPiece3 = u:D
customPiece4 = w:DWF
cast = false
pieceDrops = true
capturesToHand = true
immobilityIllegal = true
soldier = p
knight = n
bishop = b
rook = r
king = k
queen = q
commoner = g
dragonHorse = h
bers = d
alfil = a
archbishop = c
chancellor = m
fers = f
wazir = v
centaur = t
promotionRank = 7
promotedPieceType = p:g n:o b:h r:d a:c v:m f:q s:w u:t
doubleStep = false
perpetualCheckIllegal = true
nMoveRule = 0
nFoldValue = loss
stalemateValue = loss
flagPiece = k
whiteFlag = *9
blackFlag = *1

Can you fix Pandemonium like this?

Regarding number 2,

[parahouse]
variantTemplate = shogi
pieceToCharTable = PNBR.Q.HD..++++.+.++Kpnbr.q.hd..++++.+.++k
maxFile = 9
maxRank = 9
pocketSize = 7
startFen = rnbdkhbnr/4q4/ppppppppp/9/9/9/PPPPPPPPP/4Q4/RNBHKDBNR[] w - - 0 1
customPiece1 = a:QN
customPiece2 = t:BNW
customPiece3 = s:RNF
cast = false
capturesToHand = true
pieceDrops = true
dropNoDoubled = p
immobilityIllegal = true
shogiPawn = p
knight = n
bishop = b
rook = r
queen = q
dragonHorse = h
bers = d
king = k
commoner = g
centaur = j
archbishop = c
chancellor = m
promotionRank = 7
promotedPieceType = p:g n:j b:c r:m q:a h:t d:s
doubleStep = false
perpetualCheckIllegal = true
nMoveRule = 0
nFoldValue = loss
stalemateValue = loss
flagPiece = k
whiteFlag = *9
blackFlag = *1

Can you create Parahouse (New chess variant) like this?

//

I'm sorry if this is an unreasonable request...