### PR TITLE
Update variants.ini

### DIFF
--- a/src/variants.ini
+++ b/src/variants.ini
@@ -786,3 +786,37 @@ stalemateValue = loss
 flagPiece = k
 whiteFlag = *9
 blackFlag = *1
+
+# Parahouse, but no Drop rule
+[paragi]
+variantTemplate = shogi
+pieceToCharTable = PNBR.Q.HD..++++.+.++Kpnbr.q.hd..++++.+.++k
+maxFile = 9
+maxRank = 9
+pocketSize = 7
+startFen = rnbdkhbnr/4q4/ppppppppp/9/9/9/PPPPPPPPP/4Q4/RNBHKDBNR[] w - - 0 1
+customPiece1 = a:QN
+customPiece2 = t:BNW
+customPiece3 = s:RNF
+castling = false
+shogiPawn = p
+knight = n
+bishop = b
+rook = r
+queen = q
+dragonHorse = h
+bers = d
+king = k
+commoner = g
+centaur = j
+archbishop = c
+chancellor = m
+promotionRank = 7
+promotedPieceType = p:g n:j b:c r:m q:a h:t d:s
+perpetualCheckIllegal = true
+nMoveRule = 0
+nFoldValue = loss
+stalemateValue = loss
+flagPiece = k
+whiteFlag = *9
+blackFlag = *1


### PR DESCRIPTION
I'm sorry, but can you please add Paragi (Parahouse without drop) ?

# Parahouse, but no Drop rule
[paragi]
variantTemplate = shogi
pieceToCharTable = PNBR.Q.HD..++++.+.++Kpnbr.q.hd..++++.+.++k
maxFile = 9
maxRank = 9
pocketSize = 7
startFen = rnbdkhbnr/4q4/ppppppppp/9/9/9/PPPPPPPPP/4Q4/RNBHKDBNR[] w - - 0 1
customPiece1 = a:QN
customPiece2 = t:BNW
customPiece3 = s:RNF
castling = false
shogiPawn = p
knight = n
bishop = b
rook = r
queen = q
dragonHorse = h
bers = d
king = k
commoner = g
centaur = j
archbishop = c
chancellor = m
promotionRank = 7
promotedPieceType = p:g n:j b:c r:m q:a h:t d:s
perpetualCheckIllegal = true
nMoveRule = 0
nFoldValue = loss
stalemateValue = loss
flagPiece = k
whiteFlag = *9
blackFlag = *1
