### PR TITLE
add brain mode

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -22,6 +22,8 @@
 #include <cstring>   // For std::memset
 #include <iostream>
 #include <sstream>
+#include <chrono>
+#include <thread>
 
 #include "evaluate.h"
 #include "misc.h"
@@ -230,8 +232,10 @@ void MainThread::search() {
   // GUI sends a "stop" or "ponderhit" command. We therefore simply wait here
   // until the GUI sends one of those commands.
 
-  while (!Threads.stop && (ponder || Limits.infinite))
-  {} // Busy wait for a stop or a ponder reset
+  while (!Threads.stop && (ponder || Limits.infinite || brain))
+  {	  
+  if (brain) { std::this_thread::sleep_for(std::chrono::milliseconds(100));  break; } 
+  } // Busy wait for a stop or a ponder reset
 
   // Stop the threads if not already stopped (also raise the stop if
   // "ponderhit" just reset Threads.ponder).
@@ -1944,6 +1948,8 @@ void MainThread::check_time() {
   // We should not stop pondering until told so by the GUI
   if (ponder)
       return;
+  if (brain)
+	  return;
 
   if (   rootPos.two_boards()
       && Time.elapsed() < Limits.time[rootPos.side_to_move()] - 1000

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -178,13 +178,14 @@ void ThreadPool::clear() {
 /// returns immediately. Main thread will wake up other threads and start the search.
 
 void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
-                                const Search::LimitsType& limits, bool ponderMode) {
+                                const Search::LimitsType& limits, bool ponderMode,  bool brainmode) {
 
   main()->wait_for_search_finished();
 
   main()->stopOnPonderhit = stop = abort = false;
   increaseDepth = true;
   main()->ponder = ponderMode;
+  main()->brain = brainmode;
   Search::Limits = limits;
   Search::RootMoves rootMoves;
 

--- a/src/thread.h
+++ b/src/thread.h
@@ -104,7 +104,7 @@ struct MainThread : public Thread {
 
 struct ThreadPool : public std::vector<Thread*> {
 
-  void start_thinking(Position&, StateListPtr&, const Search::LimitsType&, bool = false);
+  void start_thinking(Position&, StateListPtr&, const Search::LimitsType&, bool = false, bool = false);
   void clear();
   void set(size_t);
 

--- a/src/thread.h
+++ b/src/thread.h
@@ -93,6 +93,7 @@ struct MainThread : public Thread {
   int callsCnt;
   bool stopOnPonderhit;
   std::atomic_bool ponder;
+  std::atomic_bool brain;
   Thread* bestThread; // to fetch best move when in XBoard mode
 };
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -132,6 +132,7 @@ namespace {
     Search::LimitsType limits;
     string token;
     bool ponderMode = false;
+    bool brainMode = false;
 
     limits.startTime = now(); // As early as possible!
 
@@ -156,6 +157,7 @@ namespace {
         else if (token == "perft")     is >> limits.perft;
         else if (token == "infinite")  limits.infinite = 1;
         else if (token == "ponder")    ponderMode = true;
+        else if (token == "brain")     brainMode = true;
         // UCCI commands
         else if (token == "time")         is >> limits.time[pos.side_to_move()], limits.time[pos.side_to_move()] *= secResolution;
         else if (token == "opptime")      is >> limits.time[~pos.side_to_move()], limits.time[~pos.side_to_move()] *= secResolution;
@@ -171,7 +173,7 @@ namespace {
             limits.time[BLACK] += byoyomi;
         }
 
-    Threads.start_thinking(pos, states, limits, ponderMode);
+    Threads.start_thinking(pos, states, limits, ponderMode,brainMode);
   }
 
   // bench() is called when engine receives the "bench" command. Firstly

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -173,7 +173,7 @@ namespace {
             limits.time[BLACK] += byoyomi;
         }
 
-    Threads.start_thinking(pos, states, limits, ponderMode,brainMode);
+    Threads.start_thinking(pos, states, limits, ponderMode, brainMode);
   }
 
   // bench() is called when engine receives the "bench" command. Firstly


### PR DESCRIPTION
Brain Mode is A Feature That Make Stronger Chess Engine , The Idea of Brain Mode Is Base Of ChessBase Authors , They Found A Lot Of Process May Cause Reduce CPU Performance & Cause Calculate Wrong Best Move 

_In engine tournaments, if two engines are playing against each other, using permanent brain slows down the side that is computing the next move (because it has to share resources with the other side's permanent brain)_

http://help.chessbase.com/Fritz/15/Eng/index.html?000028.htm

This method is currently used by ChessBase GUI (Fritz , Komodo , ..) As **Permanent Brain** 