### PR TITLE
Add in-built support for Miguel Illescas' Dragon Chess.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The games currently supported besides chess are listed below. Fairy-Stockfish ca
 - [Atomic](https://en.wikipedia.org/wiki/Atomic_chess)
 - [Horde](https://en.wikipedia.org/wiki/Dunsany%27s_Chess#Horde_Chess), [Maharajah and the Sepoys](https://en.wikipedia.org/wiki/Maharajah_and_the_Sepoys)
 - [Knightmate](https://www.chessvariants.com/diffobjective.dir/knightmate.html), [Nightrider](https://en.wikipedia.org/wiki/Nightrider_(chess)), [Grasshopper](https://en.wikipedia.org/wiki/Grasshopper_chess)
+- [Dragon Chess](https://www.edami.com/dragonchess/)
 
 ### Shogi variants
 - [Minishogi](https://en.wikipedia.org/wiki/Minishogi), [EuroShogi](https://en.wikipedia.org/wiki/EuroShogi), [Judkins shogi](https://en.wikipedia.org/wiki/Judkins_shogi)
@@ -80,7 +81,7 @@ See the [Fairy-Stockfish Wiki](https://github.com/ianfab/Fairy-Stockfish/wiki) f
 
 ## Bindings
 
-Besides the C++ engine, this project also includes bindings for other programming languages in order to be able to use it as a library for chess variants. They support move, SAN, and FEN generation, as well as checking of game end conditions for all variants supported by Fairy-Stockfish. Since the bindings are using the C++ code, they are very performant compared to libraries directly written in the respective target language.  
+Besides the C++ engine, this project also includes bindings for other programming languages in order to be able to use it as a library for chess variants. They support move, SAN, and FEN generation, as well as checking of game end conditions for all variants supported by Fairy-Stockfish. Since the bindings are using the C++ code, they are very performant compared to libraries directly written in the respective target language.
 
 ### Python
 

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -560,12 +560,14 @@ namespace {
     // square on the back rank instead of making a normal move.
     Variant* dragon_variant() {
         Variant *v = chess_variant_base()->init();
-        v->variantTemplate = "dragon";
+        v->variantTemplate = "bughouse";
         v->pieceToCharTable = "PNBRQ............D...Kpnbrq............d...k";
         v->add_piece(ARCHBISHOP, 'd');
         v->startFen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR[Dd] w KQkq - 0 1";
         v->pieceDrops = true;
         v->capturesToHand = false;
+        v->whiteDropRegion = Rank1BB;
+        v->blackDropRegion = Rank8BB;
         return v;
     }
     // Base used for most shogi variants

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -86,7 +86,7 @@ namespace {
         v->castling = false;
         v->doubleStep = false;
         return v;
-    } 
+    }
     // Makruk (Thai Chess)
     // https://en.wikipedia.org/wiki/Makruk
     Variant* makruk_variant() {
@@ -550,6 +550,22 @@ namespace {
         v->variantTemplate = "crazyhouse";
         v->pieceDrops = true;
         v->capturesToHand = true;
+        return v;
+    }
+    // Dragon Chess
+    // 8x8 variant invented by Miguel Illescas:
+    // https://www.edami.com/dragonchess/
+    // Like regular chess, but with an extra piece, the dragon, which moves like
+    // an archbishop (i.e. bishop+knight). The dragon can be dropped at an empty
+    // square on the back rank instead of making a normal move.
+    Variant* dragon_variant() {
+        Variant *v = chess_variant_base()->init();
+        v->variantTemplate = "dragon";
+        v->pieceToCharTable = "PNBRQ............D...Kpnbrq............d...k";
+        v->add_piece(ARCHBISHOP, 'd');
+        v->startFen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR[Dd] w KQkq - 0 1";
+        v->pieceDrops = true;
+        v->capturesToHand = false;
         return v;
     }
     // Base used for most shogi variants
@@ -1469,6 +1485,7 @@ void VariantMap::init() {
     add("sittuyin", sittuyin_variant());
     add("seirawan", seirawan_variant());
     add("shouse", shouse_variant());
+    add("dragon", dragon_variant());
     add("minishogi", minishogi_variant());
     add("mini", minishogi_variant());
     add("kyotoshogi", kyotoshogi_variant());


### PR DESCRIPTION
I'm trying to help Miguel Illescas popularise this variant, and adding support to Fairy-Stockfish would be a good step in that direction. I'm planning to train an NNUE evaluation for this variant soon, too.

Phenomenal project, by the way! Back when I started writing the program that eventually became Stockfish, I couldn't in my wildest dream imagine that it would some day develop into something as awesome as this. Thank you so much for your work! 