### PR TITLE
Bump ffish version to 0.6.9

### DIFF
--- a/tests/js/package.json
+++ b/tests/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffish",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "A high performance WebAssembly chess variant library based on Fairy-Stockfish",
   "main": "ffish.js",
   "scripts": {


### PR DESCRIPTION
New ffish version 0.6.9 because Cambodian rules in Fairy-Stockfish have been implemented.
Packages are available on
* https://www.npmjs.com/package/ffish
* https://www.npmjs.com/package/ffish-es6