### PR TITLE
Bump pyffish version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ pyffish_module = Extension(
     sources=sources,
     extra_compile_args=args)
 
-setup(name="pyffish", version="0.0.72",
+setup(name="pyffish", version="0.0.73",
       description="Fairy-Stockfish Python wrapper",
       long_description=long_description,
       long_description_content_type="text/markdown",

--- a/src/pyffish.cpp
+++ b/src/pyffish.cpp
@@ -54,7 +54,7 @@ void buildPosition(Position& pos, StateListPtr& states, const char *variant, con
 }
 
 extern "C" PyObject* pyffish_version(PyObject* self) {
-    return Py_BuildValue("(iii)", 0, 0, 72);
+    return Py_BuildValue("(iii)", 0, 0, 73);
 }
 
 extern "C" PyObject* pyffish_info(PyObject* self) {


### PR DESCRIPTION
Ada already published a new pyffish (source only!) package with this version on PYPI, but seems the version bump was missing from her latest PRs.
That 0.0.73 pyffish is a source only release, causing your FairyFishGUI pyinstaller action fail (because there are no wheels for latest pyffish in pypi, just the source). All in all I want to remedy this, and upload the missing pyffish wheels.