### PR TITLE
Update xboard.cpp - remove command

### DIFF
--- a/src/xboard.cpp
+++ b/src/xboard.cpp
@@ -380,6 +380,17 @@ void StateMachine::process_command(std::string token, std::istringstream& is) {
               go(analysisLimits);
       }
   }
+  else if (token == "remove")
+  {
+      stop();
+      if (moveList.size())
+      {
+          undo_move();
+          undo_move();
+          if (Options["UCI_AnalyseMode"])
+              go(analysisLimits);
+      }
+  }
   // Bughouse commands
   else if (token == "partner")
       Partner.parse_partner(is);


### PR DESCRIPTION
Adding remove command xboard sends when pressing Ctrl+X, only sent when player's turn, go back two moves to players previous turn. Allows player to go back and try different moves without engine stopping like undo, see https://www.gnu.org/software/xboard/engine-intf.html#8 for differences between undo and remove. 

From xboard debug file, when trying to retract move with Ctrl+X
```
13827 >first : remove
13829 <first : Error (unknown command): remove
```

Currently 'remove' is an unknown command to Fairy-SF and there's a distinction in the xboard protocol between undo and remove. I've had issues when trying to retract and play different moves against the engine. This is my hacky solution, I just copied the undo code and call undo_move() twice. Calling it once or using undo doesn't work, the engine gets out of sync with game only goes back one move, calls illegal moves, and stops playing.