### PR TITLE
enable bit manipulation instruction set 1

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -571,7 +571,7 @@ endif
 ifeq ($(avx2),yes)
 	CXXFLAGS += -DUSE_AVX2
 	ifeq ($(comp),$(filter $(comp),gcc clang mingw))
-		CXXFLAGS += -mavx2
+		CXXFLAGS += -mavx2 -mbmi
 	endif
 endif
 


### PR DESCRIPTION
A trivial improvement from upstream:

```
bmi1 enables the use of _blsr_u64 for pop_lsb, and is availabe when avx2 is.

verified a small speedup (0.2 - 0.6%)

closes https://github.com/official-stockfish/Stockfish/pull/4202

No functional change
```