### PR TITLE
Update ffish-test deployment link

### DIFF
--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -287,4 +287,4 @@ A simple toy website which demonstrates the core functionality of ffish.js and [
 
 Source code: https://github.com/thearst3rd/ffish-test
 
-See it deployed at: https://ffish-test.herokuapp.com
+See it deployed at: https://thearst3rd.github.io/ffish-test/


### PR DESCRIPTION
Hi! Small pull request.

Heroku is ending support for free dynos, and my example "ffish-test" project was being hosted there. It only needed to serve static assets anyways, so I got it running on GitHub pages now. This PR updates the project link to the new deployment link.

CC @QueensGambit 