### PR TITLE
Support wall squares

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The games currently supported besides chess are listed below. Fairy-Stockfish ca
 - [Chess960](https://en.wikipedia.org/wiki/Chess960), [Placement/Pre-Chess](https://www.chessvariants.com/link/placement-chess)
 - [Crazyhouse](https://en.wikipedia.org/wiki/Crazyhouse), [Loop](https://en.wikipedia.org/wiki/Crazyhouse#Variations), [Chessgi](https://en.wikipedia.org/wiki/Crazyhouse#Variations), [Pocket Knight](http://www.chessvariants.com/other.dir/pocket.html), Capablanca-Crazyhouse
 - [Bughouse](https://en.wikipedia.org/wiki/Bughouse_chess), [Koedem](http://schachclub-oetigheim.de/wp-content/uploads/2016/04/Koedem-rules.pdf)
-- [Seirawan](https://en.wikipedia.org/wiki/Seirawan_chess), Seirawan-Crazyhouse
+- [Seirawan](https://en.wikipedia.org/wiki/Seirawan_chess), Seirawan-Crazyhouse, [Dragon Chess](https://www.edami.com/dragonchess/)
 - [Amazon](https://www.chessvariants.com/diffmove.dir/amazone.html), [Chigorin](https://www.chessvariants.com/diffsetup.dir/chigorin.html), [Almost chess](https://en.wikipedia.org/wiki/Almost_Chess)
 - [Hoppel-Poppel](http://www.chessvariants.com/diffmove.dir/hoppel-poppel.html), New Zealand
 - [Antichess](https://lichess.org/variant/antichess), [Giveaway](http://www.chessvariants.com/diffobjective.dir/giveaway.old.html), [Suicide](https://www.freechess.org/Help/HelpFiles/suicide_chess.html), [Losers](https://www.chessclub.com/help/Wild17), [Codrus](http://www.binnewirtz.com/Schlagschach1.htm)
@@ -56,7 +56,7 @@ The games currently supported besides chess are listed below. Fairy-Stockfish ca
 - [Atomic](https://en.wikipedia.org/wiki/Atomic_chess)
 - [Horde](https://en.wikipedia.org/wiki/Dunsany%27s_Chess#Horde_Chess), [Maharajah and the Sepoys](https://en.wikipedia.org/wiki/Maharajah_and_the_Sepoys)
 - [Knightmate](https://www.chessvariants.com/diffobjective.dir/knightmate.html), [Nightrider](https://en.wikipedia.org/wiki/Nightrider_(chess)), [Grasshopper](https://en.wikipedia.org/wiki/Grasshopper_chess)
-- [Dragon Chess](https://www.edami.com/dragonchess/)
+- [Duck chess](https://duckchess.com/), [Omicron](http://www.eglebbk.dds.nl/program/chess-omicron.html), [Gustav III](https://www.chessvariants.com/play/gustav-iiis-chess)
 
 ### Shogi variants
 - [Minishogi](https://en.wikipedia.org/wiki/Minishogi), [EuroShogi](https://en.wikipedia.org/wiki/EuroShogi), [Judkins shogi](https://en.wikipedia.org/wiki/Judkins_shogi)

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ if platform.python_compiler().startswith("MSC"):
 else:
     args = ["-std=c++17", "-flto", "-Wno-date-time"]
 
-args.extend(["-DLARGEBOARDS", "-DPRECOMPUTED_MAGICS", "-DNNUE_EMBEDDING_OFF"])
+args.extend(["-DLARGEBOARDS", "-DALLVARS", "-DPRECOMPUTED_MAGICS", "-DNNUE_EMBEDDING_OFF"])
 
 if "64bit" in platform.architecture():
     args.append("-DIS_64BIT")

--- a/src/Makefile
+++ b/src/Makefile
@@ -348,7 +348,7 @@ ifeq ($(nnue),no)
 	CXXFLAGS += -DNNUE_EMBEDDING_OFF
 endif
 
-# Enable all variants, even heavyweight ones like amazons
+# Enable all variants, even heavyweight ones like duck and amazons
 ifneq ($(all),no)
 	CXXFLAGS += -DALLVARS
 endif

--- a/src/Makefile_js
+++ b/src/Makefile_js
@@ -27,6 +27,7 @@ CXX=emcc
 CXXFLAGS += --bind -DNNUE_EMBEDDING_OFF -DNO_THREADS -std=c++17 -Wall
 
 largeboards = yes
+all = yes
 optimize = yes
 debug = no
 
@@ -46,6 +47,11 @@ endif
 # Use precomputed magics by default
 ifneq ($(largeboards),no)
 	CXXFLAGS += -DLARGEBOARDS -DPRECOMPUTED_MAGICS -s TOTAL_MEMORY=32MB -s ALLOW_MEMORY_GROWTH=1 -s WASM_MEM_MAX=1GB
+endif
+
+# Enable all variants, even heavyweight ones like duck and amazons
+ifneq ($(all),no)
+	CXXFLAGS += -DALLVARS
 endif
 
 ### Compile as ES6/ES2015 module

--- a/src/apiutil.h
+++ b/src/apiutil.h
@@ -345,6 +345,10 @@ inline const std::string move_to_san(Position& pos, Move m, Notation n) {
             san += std::string("/") + (char)toupper(pos.piece_to_char()[make_piece(us, gating_type(m))]);
     }
 
+    // Wall square
+    if (pos.wall_gating())
+        san += "," + square(pos, gating_square(m), n);
+
     // Check and checkmate
     if (pos.gives_check(m) && !is_shogi(n) && n != NOTATION_XIANGQI_WXF)
     {
@@ -885,13 +889,13 @@ inline Validation check_digit_field(const std::string& field) {
 }
 
 inline std::string get_valid_special_chars(const Variant* v) {
-    std::string validSpecialCharactersFirstField = "/";
+    std::string validSpecialCharactersFirstField = "/*";
     // Whether or not '-', '+', '~', '[', ']' are valid depends on the variant being played.
     if (v->shogiStylePromotions)
         validSpecialCharactersFirstField += '+';
     if (!v->promotionPieceTypes.empty())
         validSpecialCharactersFirstField += '~';
-    if (!v->freeDrops && (v->pieceDrops || v->seirawanGating || v->arrowGating))
+    if (!v->freeDrops && (v->pieceDrops || v->seirawanGating))
         validSpecialCharactersFirstField += "[-]";
     return validSpecialCharactersFirstField;
 }
@@ -935,7 +939,7 @@ inline FenValidation validate_fen(const std::string& fen, const Variant* v, bool
 
     // check for pocket
     std::string pocket = "";
-    if (v->pieceDrops || v->seirawanGating || v->arrowGating)
+    if (v->pieceDrops || v->seirawanGating)
     {
         if (check_pocket_info(fenParts[0], nbRanks, v, pocket) == NOK)
             return FEN_INVALID_POCKET_INFO;

--- a/src/apiutil.h
+++ b/src/apiutil.h
@@ -555,7 +555,9 @@ inline Validation fill_char_board(CharBoard& board, const std::string& fenBoard,
     {
         if (c == ' ' || c == '[')
             break;
-        if (isdigit(c))
+        if (c == '*')
+            ++fileIdx;
+        else if (isdigit(c))
         {
             fileIdx += c - '0';
             // if we have multiple digits attached we can add multiples of 9 to compute the resulting number (e.g. -> 21 = 2 + 2 * 9 + 1)

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -332,9 +332,6 @@ namespace {
                : Type == CAPTURES     ?  pos.pieces(~Us)
                                       : ~pos.pieces(   ); // QUIETS || QUIET_CHECKS
 
-        // Remove wall squares
-        target &= ~pos.state()->wallSquares;
-
         if (Type == EVASIONS)
         {
             if (pos.checkers() & pos.non_sliding_riders())
@@ -345,6 +342,7 @@ namespace {
                 target = pos.checkers();
         }
 
+        // Remove inaccesible squares (outside board + wall squares)
         target &= pos.board_bb();
 
         moveList = generate_pawn_moves<Us, Type>(pos, moveList, target);

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -26,22 +26,29 @@ namespace Stockfish {
 namespace {
 
   template<MoveType T>
-  ExtMove* make_move_and_gating(const Position& pos, ExtMove* moveList, Color us, Square from, Square to) {
+  ExtMove* make_move_and_gating(const Position& pos, ExtMove* moveList, Color us, Square from, Square to, PieceType pt = NO_PIECE_TYPE) {
 
-    // Arrow gating moves
-    if (pos.arrow_gating())
+    // Wall placing moves
+    if (pos.wall_gating())
     {
-        for (PieceType pt_gating : pos.piece_types())
-            if (pos.can_drop(us, pt_gating))
-            {
-                Bitboard b = pos.drop_region(us, pt_gating) & moves_bb(us, type_of(pos.piece_on(from)), to, pos.pieces() ^ from) & ~(pos.pieces() ^ from);
-                while (b)
-                    *moveList++ = make_gating<T>(from, to, pt_gating, pop_lsb(b));
-            }
+        Bitboard b = pos.board_bb() & ~((pos.pieces() ^ from) | to);
+        if (T == CASTLING)
+        {
+            Square kto = make_square(to > from ? pos.castling_kingside_file() : pos.castling_queenside_file(), pos.castling_rank(us));
+            Direction step = kto > from ? EAST : WEST;
+            Square rto = kto - step;
+            b ^= square_bb(to) ^ kto ^ rto;
+        }
+        if (T == EN_PASSANT)
+            b ^= to - pawn_push(us);
+        if (pos.variant()->arrowGating)
+            b &= moves_bb(us, type_of(pos.piece_on(from)), to, pos.pieces() ^ from);
+        while (b)
+            *moveList++ = make_gating<T>(from, to, pt, pop_lsb(b));
         return moveList;
     }
 
-    *moveList++ = make<T>(from, to);
+    *moveList++ = make<T>(from, to, pt);
 
     // Gating moves
     if (pos.seirawan_gating() && (pos.gates(us) & from))
@@ -63,10 +70,10 @@ namespace {
     {
         for (PieceType pt : pos.promotion_piece_types())
             if (!pos.promotion_limit(pt) || pos.promotion_limit(pt) > pos.count(c, pt))
-                *moveList++ = make<PROMOTION>(to - D, to, pt);
+                moveList = make_move_and_gating<PROMOTION>(pos, moveList, pos.side_to_move(), to - D, to, pt);
         PieceType pt = pos.promoted_piece_type(PAWN);
         if (pt && !(pos.piece_promotion_on_capture() && pos.empty(to)))
-            *moveList++ = make<PIECE_PROMOTION>(to - D, to);
+            moveList = make_move_and_gating<PIECE_PROMOTION>(pos, moveList, pos.side_to_move(), to - D, to);
     }
 
     return moveList;
@@ -147,13 +154,13 @@ namespace {
         while (b1)
         {
             Square to = pop_lsb(b1);
-            *moveList++ = make_move(to - Up, to);
+            moveList = make_move_and_gating<NORMAL>(pos, moveList, Us, to - Up, to);
         }
 
         while (b2)
         {
             Square to = pop_lsb(b2);
-            *moveList++ = make_move(to - Up - Up, to);
+            moveList = make_move_and_gating<NORMAL>(pos, moveList, Us, to - Up - Up, to);
         }
     }
 
@@ -216,13 +223,13 @@ namespace {
         while (b1)
         {
             Square to = pop_lsb(b1);
-            *moveList++ = make_move(to - UpRight, to);
+            moveList = make_move_and_gating<NORMAL>(pos, moveList, Us, to - UpRight, to);
         }
 
         while (b2)
         {
             Square to = pop_lsb(b2);
-            *moveList++ = make_move(to - UpLeft, to);
+            moveList = make_move_and_gating<NORMAL>(pos, moveList, Us, to - UpLeft, to);
         }
 
         if (pos.ep_square() != SQ_NONE)
@@ -238,7 +245,7 @@ namespace {
             assert(b1);
 
             while (b1)
-                *moveList++ = make<EN_PASSANT>(pop_lsb(b1), pos.ep_square());
+                moveList = make_move_and_gating<EN_PASSANT>(pos, moveList, Us, pop_lsb(b1), pos.ep_square());
         }
     }
 
@@ -324,6 +331,9 @@ namespace {
                : Type == NON_EVASIONS ? ~pos.pieces( Us)
                : Type == CAPTURES     ?  pos.pieces(~Us)
                                       : ~pos.pieces(   ); // QUIETS || QUIET_CHECKS
+
+        // Remove wall squares
+        target &= ~pos.state()->wallSquares;
 
         if (Type == EVASIONS)
         {

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -88,7 +88,7 @@ enum StatsType { NoCaptures, Captures };
 /// the move's from and to squares, see www.chessprogramming.org/Butterfly_Boards
 typedef Stats<int16_t, 13365, COLOR_NB, int(SQUARE_NB + 1) * int(1 << SQUARE_BITS)> ButterflyHistory;
 
-typedef Stats<int16_t, 5000, COLOR_NB, SQUARE_NB> GateHistory;
+typedef Stats<int16_t, 13365, COLOR_NB, SQUARE_NB> GateHistory;
 
 /// At higher depths LowPlyHistory records successful quiet moves near the root
 /// and quiet moves which are/were in the PV (ttPv). It is cleared with each new

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -88,6 +88,8 @@ enum StatsType { NoCaptures, Captures };
 /// the move's from and to squares, see www.chessprogramming.org/Butterfly_Boards
 typedef Stats<int16_t, 13365, COLOR_NB, int(SQUARE_NB + 1) * int(1 << SQUARE_BITS)> ButterflyHistory;
 
+typedef Stats<int16_t, 5000, COLOR_NB, SQUARE_NB> GateHistory;
+
 /// At higher depths LowPlyHistory records successful quiet moves near the root
 /// and quiet moves which are/were in the PV (ttPv). It is cleared with each new
 /// search and filled during iterative deepening.
@@ -124,12 +126,14 @@ class MovePicker {
 public:
   MovePicker(const MovePicker&) = delete;
   MovePicker& operator=(const MovePicker&) = delete;
-  MovePicker(const Position&, Move, Value, const CapturePieceToHistory*);
+  MovePicker(const Position&, Move, Value, const GateHistory*, const CapturePieceToHistory*);
   MovePicker(const Position&, Move, Depth, const ButterflyHistory*,
+                                           const GateHistory*,
                                            const CapturePieceToHistory*,
                                            const PieceToHistory**,
                                            Square);
   MovePicker(const Position&, Move, Depth, const ButterflyHistory*,
+                                           const GateHistory*,
                                            const LowPlyHistory*,
                                            const CapturePieceToHistory*,
                                            const PieceToHistory**,
@@ -146,6 +150,7 @@ private:
 
   const Position& pos;
   const ButterflyHistory* mainHistory;
+  const GateHistory* gateHistory;
   const LowPlyHistory* lowPlyHistory;
   const CapturePieceToHistory* captureHistory;
   const PieceToHistory** continuationHistory;

--- a/src/nnue/features/half_ka_v2_variants.cpp
+++ b/src/nnue/features/half_ka_v2_variants.cpp
@@ -53,7 +53,7 @@ namespace Stockfish::Eval::NNUE::Features {
     ValueListInserter<IndexType> active
   ) {
     Square oriented_ksq = orient(perspective, pos.nnue_king_square(perspective), pos);
-    Bitboard bb = pos.pieces();
+    Bitboard bb = pos.pieces(WHITE) | pos.pieces(BLACK);
     while (bb)
     {
       Square s = pop_lsb(bb);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -328,6 +328,7 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
     parse_attribute("immobilityIllegal", v->immobilityIllegal);
     parse_attribute("gating", v->gating);
     parse_attribute("arrowGating", v->arrowGating);
+    parse_attribute("duckGating", v->duckGating);
     parse_attribute("seirawanGating", v->seirawanGating);
     parse_attribute("cambodianMoves", v->cambodianMoves);
     parse_attribute("diagonalLines", v->diagonalLines);
@@ -434,7 +435,8 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
             std::cerr << "Inconsistent settings: castlingQueensideFile > castlingKingsideFile." << std::endl;
 
         // Check for limitations
-
+        if (v->pieceDrops && (v->arrowGating || v->duckGating))
+            std::cerr << "pieceDrops and arrowGating/duckGating are incompatible." << std::endl;
         // Options incompatible with royal kings
         if (v->pieceTypes.find(KING) != v->pieceTypes.end())
         {
@@ -442,6 +444,8 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
                 std::cerr << "Can not use kings with blastOnCapture." << std::endl;
             if (v->flipEnclosedPieces)
                 std::cerr << "Can not use kings with flipEnclosedPieces." << std::endl;
+            if (v->duckGating)
+                std::cerr << "Can not use kings with duckGating." << std::endl;
             // We can not fully check support for custom king movements at this point,
             // since custom pieces are only initialized on loading of the variant.
             // We will assume this is valid, but it might cause problems later if it's not.

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -293,6 +293,7 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
     parse_attribute("mandatoryPiecePromotion", v->mandatoryPiecePromotion);
     parse_attribute("pieceDemotion", v->pieceDemotion);
     parse_attribute("blastOnCapture", v->blastOnCapture);
+    parse_attribute("petrifyOnCapture", v->petrifyOnCapture);
     parse_attribute("doubleStep", v->doubleStep);
     parse_attribute("doubleStepRank", v->doubleStepRank);
     parse_attribute("doubleStepRankMin", v->doubleStepRankMin);

--- a/src/position.h
+++ b/src/position.h
@@ -54,6 +54,7 @@ struct StateInfo {
   CheckCount checksRemaining[COLOR_NB];
   Square epSquare;
   Square castlingKingSquare[COLOR_NB];
+  Bitboard wallSquares;
   Bitboard gatesBB[COLOR_NB];
 
   // Not copied when making a move (will be recomputed anyhow)
@@ -171,7 +172,7 @@ public:
   PieceType drop_no_doubled() const;
   bool immobility_illegal() const;
   bool gating() const;
-  bool arrow_gating() const;
+  bool wall_gating() const;
   bool seirawan_gating() const;
   bool cambodian_moves() const;
   Bitboard diagonal_lines() const;
@@ -723,9 +724,9 @@ inline bool Position::gating() const {
   return var->gating;
 }
 
-inline bool Position::arrow_gating() const {
+inline bool Position::wall_gating() const {
   assert(var != nullptr);
-  return var->arrowGating;
+  return var->arrowGating || var->duckGating;
 }
 
 inline bool Position::seirawan_gating() const {

--- a/src/position.h
+++ b/src/position.h
@@ -395,7 +395,7 @@ inline bool Position::two_boards() const {
 
 inline Bitboard Position::board_bb() const {
   assert(var != nullptr);
-  return board_size_bb(var->maxFile, var->maxRank);
+  return board_size_bb(var->maxFile, var->maxRank) & ~st->wallSquares;
 }
 
 inline Bitboard Position::board_bb(Color c, PieceType pt) const {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -800,6 +800,8 @@ namespace {
             {
                 int penalty = -stat_bonus(depth);
                 thisThread->mainHistory[us][from_to(ttMove)] << penalty;
+                if (pos.wall_gating())
+                    thisThread->gateHistory[us][gating_square(ttMove)] << penalty;
                 update_continuation_histories(ss, pos.moved_piece(ttMove), to_sq(ttMove), penalty);
             }
         }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -280,7 +280,14 @@ void MainThread::search() {
       // Send move only when not in analyze mode and not at game end
       if (!Limits.infinite && !ponder && rootMoves[0].pv[0] != MOVE_NONE && !Threads.abort.exchange(true))
       {
-          sync_cout << "move " << UCI::move(rootPos, bestMove) << sync_endl;
+          std::string move = UCI::move(rootPos, bestMove);
+          if (rootPos.wall_gating())
+          {
+              sync_cout << "move " << move.substr(0, move.find(",")) << "," << sync_endl;
+              sync_cout << "move " << move.substr(move.find(",") + 1) << sync_endl;
+          }
+          else
+              sync_cout << "move " << UCI::move(rootPos, bestMove) << sync_endl;
           if (XBoard::stateMachine->moveAfterSearch)
           {
               XBoard::stateMachine->do_move(bestMove);
@@ -992,7 +999,7 @@ namespace {
     {
         assert(probCutBeta < VALUE_INFINITE);
 
-        MovePicker mp(pos, ttMove, probCutBeta - ss->staticEval, &captureHistory);
+        MovePicker mp(pos, ttMove, probCutBeta - ss->staticEval, &thisThread->gateHistory, &captureHistory);
         int probCutCount = 0;
         bool ttPv = ss->ttPv;
         ss->ttPv = false;
@@ -1071,6 +1078,7 @@ moves_loop: // When in check, search starts from here
     Move countermove = thisThread->counterMoves[pos.piece_on(prevSq)][prevSq];
 
     MovePicker mp(pos, ttMove, depth, &thisThread->mainHistory,
+                                      &thisThread->gateHistory,
                                       &thisThread->lowPlyHistory,
                                       &captureHistory,
                                       contHist,
@@ -1175,7 +1183,7 @@ moves_loop: // When in check, search starts from here
                   continue;
 
               // Prune moves with negative SEE (~20 Elo)
-              if (!pos.see_ge(move, Value(-(30 - std::min(lmrDepth, 18) + 10 * !!pos.capture_the_flag_piece()) * lmrDepth * lmrDepth)))
+              if (!pos.variant()->duckGating && !pos.see_ge(move, Value(-(30 - std::min(lmrDepth, 18) + 10 * !!pos.capture_the_flag_piece()) * lmrDepth * lmrDepth)))
                   continue;
           }
       }
@@ -1315,6 +1323,7 @@ moves_loop: // When in check, search starts from here
                   r++;
 
               ss->statScore =  thisThread->mainHistory[us][from_to(move)]
+                             + thisThread->gateHistory[us][gating_square(move)] * 3
                              + (*contHist[0])[history_slot(movedPiece)][to_sq(move)]
                              + (*contHist[1])[history_slot(movedPiece)][to_sq(move)]
                              + (*contHist[3])[history_slot(movedPiece)][to_sq(move)]
@@ -1615,6 +1624,7 @@ moves_loop: // When in check, search starts from here
     // queen promotions, and other checks (only if depth >= DEPTH_QS_CHECKS)
     // will be generated.
     MovePicker mp(pos, ttMove, depth, &thisThread->mainHistory,
+                                      &thisThread->gateHistory,
                                       &thisThread->captureHistory,
                                       contHist,
                                       to_sq((ss-1)->currentMove));
@@ -1811,13 +1821,20 @@ moves_loop: // When in check, search starts from here
         // Decrease stats for all non-best quiet moves
         for (int i = 0; i < quietCount; ++i)
         {
-            thisThread->mainHistory[us][from_to(quietsSearched[i])] << -bonus2;
+            if (from_to(quietsSearched[i]) != from_to(bestMove))
+                thisThread->mainHistory[us][from_to(quietsSearched[i])] << -bonus2;
+            if (pos.wall_gating())
+                thisThread->gateHistory[us][gating_square(quietsSearched[i])] << -bonus2;
             update_continuation_histories(ss, pos.moved_piece(quietsSearched[i]), to_sq(quietsSearched[i]), -bonus2);
         }
     }
     else
+    {
         // Increase stats for the best move in case it was a capture move
         captureHistory[moved_piece][to_sq(bestMove)][captured] << bonus1;
+        if (pos.wall_gating())
+            thisThread->gateHistory[us][gating_square(bestMove)] << bonus1;
+    }
 
     // Extra penalty for a quiet early move that was not a TT move or
     // main killer move in previous ply when it gets refuted.
@@ -1830,7 +1847,10 @@ moves_loop: // When in check, search starts from here
     {
         moved_piece = pos.moved_piece(capturesSearched[i]);
         captured = type_of(pos.piece_on(to_sq(capturesSearched[i])));
-        captureHistory[moved_piece][to_sq(capturesSearched[i])][captured] << -bonus1;
+        if (from_to(capturesSearched[i]) != from_to(bestMove))
+            captureHistory[moved_piece][to_sq(capturesSearched[i])][captured] << -bonus1;
+        if (pos.wall_gating())
+            thisThread->gateHistory[us][gating_square(capturesSearched[i])] << -bonus1;
     }
   }
 
@@ -1865,6 +1885,8 @@ moves_loop: // When in check, search starts from here
     Color us = pos.side_to_move();
     Thread* thisThread = pos.this_thread();
     thisThread->mainHistory[us][from_to(move)] << bonus;
+    if (pos.wall_gating())
+        thisThread->gateHistory[us][gating_square(move)] << bonus;
     update_continuation_histories(ss, pos.moved_piece(move), to_sq(move), bonus);
 
     // Penalty for reversed move in case of moved piece not being a pawn

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1325,7 +1325,7 @@ moves_loop: // When in check, search starts from here
                   r++;
 
               ss->statScore =  thisThread->mainHistory[us][from_to(move)]
-                             + thisThread->gateHistory[us][gating_square(move)] * 3
+                             + thisThread->gateHistory[us][gating_square(move)] * 2
                              + (*contHist[0])[history_slot(movedPiece)][to_sq(move)]
                              + (*contHist[1])[history_slot(movedPiece)][to_sq(move)]
                              + (*contHist[3])[history_slot(movedPiece)][to_sq(move)]

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1821,7 +1821,7 @@ moves_loop: // When in check, search starts from here
         // Decrease stats for all non-best quiet moves
         for (int i = 0; i < quietCount; ++i)
         {
-            if (from_to(quietsSearched[i]) != from_to(bestMove))
+            if (!(pos.wall_gating() && from_to(quietsSearched[i]) == from_to(bestMove)))
                 thisThread->mainHistory[us][from_to(quietsSearched[i])] << -bonus2;
             if (pos.wall_gating())
                 thisThread->gateHistory[us][gating_square(quietsSearched[i])] << -bonus2;
@@ -1847,7 +1847,7 @@ moves_loop: // When in check, search starts from here
     {
         moved_piece = pos.moved_piece(capturesSearched[i]);
         captured = type_of(pos.piece_on(to_sq(capturesSearched[i])));
-        if (from_to(capturesSearched[i]) != from_to(bestMove))
+        if (!(pos.wall_gating() && from_to(capturesSearched[i]) == from_to(bestMove)))
             captureHistory[moved_piece][to_sq(capturesSearched[i])][captured] << -bonus1;
         if (pos.wall_gating())
             thisThread->gateHistory[us][gating_square(capturesSearched[i])] << -bonus1;

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -61,6 +61,7 @@ void Thread::clear() {
 
   counterMoves.fill(MOVE_NONE);
   mainHistory.fill(0);
+  gateHistory.fill(0);
   lowPlyHistory.fill(0);
   captureHistory.fill(0);
 

--- a/src/thread.h
+++ b/src/thread.h
@@ -71,6 +71,7 @@ public:
   Depth rootDepth, completedDepth;
   CounterMoveHistory counterMoves;
   ButterflyHistory mainHistory;
+  GateHistory gateHistory;
   LowPlyHistory lowPlyHistory;
   CapturePieceToHistory captureHistory;
   ContinuationHistory continuationHistory[2][2];

--- a/src/types.h
+++ b/src/types.h
@@ -228,7 +228,7 @@ constexpr int SQUARE_BITS = 6;
 #endif
 
 #ifdef ALLVARS
-constexpr int MAX_MOVES = 4096;
+constexpr int MAX_MOVES = 8192;
 #else
 constexpr int MAX_MOVES = 1024;
 #endif

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -531,6 +531,10 @@ string UCI::move(const Position& pos, Move m) {
   string move = (type_of(m) == DROP ? UCI::dropped_piece(pos, m) + (CurrentProtocol == USI ? '*' : '@')
                                     : UCI::square(pos, from)) + UCI::square(pos, to);
 
+  // Wall square
+  if (pos.wall_gating() && CurrentProtocol == XBOARD)
+      move += "," + UCI::square(pos, to) + UCI::square(pos, gating_square(m));
+
   if (type_of(m) == PROMOTION)
       move += pos.piece_to_char()[make_piece(BLACK, promotion_type(m))];
   else if (type_of(m) == PIECE_PROMOTION)
@@ -543,6 +547,10 @@ string UCI::move(const Position& pos, Move m) {
       if (gating_square(m) != from)
           move += UCI::square(pos, gating_square(m));
   }
+
+  // Wall square
+  if (pos.wall_gating() && CurrentProtocol != XBOARD)
+      move += "," + UCI::square(pos, to) + UCI::square(pos, gating_square(m));
 
   return move;
 }

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -48,7 +48,7 @@ namespace UCI {
 std::set<string> standard_variants = {
     "normal", "nocastle", "fischerandom", "knightmate", "3check", "makruk", "shatranj",
     "asean", "seirawan", "crazyhouse", "bughouse", "suicide", "giveaway", "losers", "atomic",
-    "capablanca", "gothic", "janus", "caparandom", "grand", "shogi", "xiangqi"
+    "capablanca", "gothic", "janus", "caparandom", "grand", "shogi", "xiangqi", "duck"
 };
 
 void init_variant(const Variant* v) {

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -1313,6 +1313,26 @@ namespace {
         v->castling = false;
         return v;
     }
+    // Omicron chess
+    // Omega chess on a 12x10 board
+    // http://www.eglebbk.dds.nl/program/chess-omicron.html
+    Variant* omicron_variant() {
+        Variant* v = chess_variant_base()->init();
+        v->pieceToCharTable = "PNBRQ..C.W...........Kpnbrq..c.w...........k";
+        v->maxRank = RANK_10;
+        v->maxFile = FILE_L;
+        v->startFen = "w**********w/*crnbqkbnrc*/*pppppppppp*/*10*/*10*/*10*/*10*/*PPPPPPPPPP*/*CRNBQKBNRC*/W**********W w KQkq - 0 1";
+        v->add_piece(CUSTOM_PIECES, 'c', "DAW"); // Champion
+        v->add_piece(CUSTOM_PIECES + 1, 'w', "CF"); // Wizard
+        v->castlingKingsideFile = FILE_I;
+        v->castlingQueensideFile = FILE_E;
+        v->castlingRank = RANK_2;
+        v->promotionRank = RANK_9;
+        v->promotionPieceTypes = {CUSTOM_PIECES + 1, CUSTOM_PIECES, QUEEN, ROOK, BISHOP, KNIGHT};
+        v->doubleStepRank = RANK_3;
+        v->doubleStepRankMin = RANK_3;
+        return v;
+    }
     // Shako
     // 10x10 variant with cannons by Jean-Louis Cazaux
     // https://www.chessvariants.com/large.dir/shako.html
@@ -1575,6 +1595,7 @@ void VariantMap::init() {
     add("grand", grand_variant());
     add("opulent", opulent_variant());
     add("tencubed", tencubed_variant());
+    add("omicron", omicron_variant());
     add("shako", shako_variant());
     add("clobber10", clobber10_variant());
     add("flipello10", flipello10_variant());

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -415,6 +415,7 @@ namespace {
         v->extinctionValue = -VALUE_MATE;
         v->extinctionPieceTypes = {COMMONER};
         v->duckGating = true;
+        v->stalemateValue = VALUE_MATE;
         return v;
     }
 #endif

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -405,6 +405,19 @@ namespace {
         v->extinctionPseudoRoyal = true;
         return v;
     }
+#ifdef ALLVARS
+    // Duck chess
+    Variant* duck_variant() {
+        Variant* v = chess_variant_base()->init();
+        v->remove_piece(KING);
+        v->add_piece(COMMONER, 'k');
+        v->castlingKingPiece = COMMONER;
+        v->extinctionValue = -VALUE_MATE;
+        v->extinctionPieceTypes = {COMMONER};
+        v->duckGating = true;
+        return v;
+    }
+#endif
     // Three-check chess
     // Check the king three times to win
     // https://lichess.org/variant/threeCheck
@@ -1175,6 +1188,21 @@ namespace {
         v->promotionPieceTypes = {CENTAUR, QUEEN, ROOK, BISHOP, KNIGHT};
         return v;
     }
+    // Gustav III chess
+    // 10x8 variant with an amazon piece and wall squares
+    // https://www.chessvariants.com/play/gustav-iiis-chess
+    Variant* gustav3_variant() {
+        Variant* v = chess_variant_base()->init();
+        v->pieceToCharTable = "PNBRQ.............AKpnbrq.............ak";
+        v->maxRank = RANK_8;
+        v->maxFile = FILE_J;
+        v->castlingKingsideFile = FILE_H;
+        v->castlingQueensideFile = FILE_D;
+        v->add_piece(AMAZON, 'a');
+        v->startFen = "arnbqkbnra/*pppppppp*/*8*/*8*/*8*/*8*/*PPPPPPPP*/ARNBQKBNRA w KQkq - 0 1";
+        v->promotionPieceTypes = {AMAZON, QUEEN, ROOK, BISHOP, KNIGHT};
+        return v;
+    }
     // Jeson mor
     // Mongolian chess variant with knights only and a king of the hill like goal
     // https://en.wikipedia.org/wiki/Jeson_Mor
@@ -1332,13 +1360,12 @@ namespace {
     // https://en.wikipedia.org/wiki/Game_of_the_Amazons
     Variant* amazons_variant() {
         Variant* v = chess_variant_base()->init();
-        v->pieceToCharTable = "P...Q.................p...q.................";
+        v->pieceToCharTable = "....Q.....................q.................";
         v->maxRank = RANK_10;
         v->maxFile = FILE_J;
         v->reset_pieces();
         v->add_piece(CUSTOM_PIECES, 'q', "mQ");
-        v->add_piece(IMMOBILE_PIECE, 'p');
-        v->startFen = "3q2q3/10/10/q8q/10/10/Q8Q/10/10/3Q2Q3[PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPpppppppppppppppppppppppppppppppppppppppppppppp] w - - 0 1";
+        v->startFen = "3q2q3/10/10/q8q/10/10/Q8Q/10/10/3Q2Q3 w - - 0 1";
         v->stalemateValue = -VALUE_MATE;
         v->arrowGating = true;
         return v;
@@ -1489,6 +1516,9 @@ void VariantMap::init() {
     add("horde", horde_variant());
     add("nocheckatomic", nocheckatomic_variant());
     add("atomic", atomic_variant());
+#ifdef ALLVARS
+    add("duck", duck_variant());
+#endif
     add("3check", threecheck_variant());
     add("5check", fivecheck_variant());
     add("crazyhouse", crazyhouse_variant());
@@ -1539,6 +1569,7 @@ void VariantMap::init() {
     add("chancellor", chancellor_variant());
     add("embassy", embassy_variant());
     add("centaur", centaur_variant());
+    add("gustav3", gustav3_variant());
     add("jesonmor", jesonmor_variant());
     add("courier", courier_variant());
     add("grand", grand_variant());

--- a/src/variant.h
+++ b/src/variant.h
@@ -96,6 +96,7 @@ struct Variant {
   bool immobilityIllegal = false;
   bool gating = false;
   bool arrowGating = false;
+  bool duckGating = false;
   bool seirawanGating = false;
   bool cambodianMoves = false;
   Bitboard diagonalLines = 0;
@@ -220,7 +221,7 @@ struct Variant {
               nnueKing = NO_PIECE_TYPE;
       }
       int nnueSquares = (maxRank + 1) * (maxFile + 1);
-      nnueUsePockets = (pieceDrops && (capturesToHand || (!mustDrop && !arrowGating && pieceTypes.size() != 1))) || seirawanGating;
+      nnueUsePockets = (pieceDrops && (capturesToHand || (!mustDrop && pieceTypes.size() != 1))) || seirawanGating;
       int nnuePockets = nnueUsePockets ? 2 * int(maxFile + 1) : 0;
       int nnueNonDropPieceIndices = (2 * pieceTypes.size() - (nnueKing != NO_PIECE_TYPE)) * nnueSquares;
       int nnuePieceIndices = nnueNonDropPieceIndices + 2 * (pieceTypes.size() - (nnueKing != NO_PIECE_TYPE)) * nnuePockets;

--- a/src/variant.h
+++ b/src/variant.h
@@ -60,6 +60,7 @@ struct Variant {
   bool mandatoryPiecePromotion = false;
   bool pieceDemotion = false;
   bool blastOnCapture = false;
+  bool petrifyOnCapture = false;
   bool doubleStep = true;
   Rank doubleStepRank = RANK_2;
   Rank doubleStepRankMin = RANK_2;

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -191,7 +191,8 @@
 # dropNoDoubledCount: specifies the count of already existing pieces for dropNoDoubled [PieceType] (default: 1)
 # immobilityIllegal: pieces may not move to squares where they can never move from [bool] (default: false)
 # gating: maintain squares on backrank with extra rights in castling field of FEN [bool] (default: false)
-# arrowGating: allow gating in Game of the Amazons style [bool] (default: false)
+# arrowGating: gating of wall squares in Game of the Amazons style [bool] (default: false)
+# duckGating: gating of a wall square in Duck chess style [bool] (default: false)
 # seirawanGating: allow gating of pieces in hand like in S-Chess, requires "gating = true" [bool] (default: false)
 # cambodianMoves: enable special moves of cambodian chess, requires "gating = true" [bool] (default: false)
 # diagonalLines: enable special moves along diagonal for specific squares (Janggi) [Bitboard]

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -157,7 +157,7 @@
 # mandatoryPiecePromotion: piece promotion (and demotion if enabled) is mandatory [bool] (default: false)
 # pieceDemotion: enable demotion of pieces (e.g., Kyoto shogi) [bool] (default: false)
 # blastOnCapture: captures explode all adjacent non-pawn pieces (e.g., atomic chess) [bool] (default: false)
-# petrifyOnCapture: captures replace the capturing piece by a wall square [bool] (default: false)
+# petrifyOnCapture: non-pawn pieces are turned into wall squares when capturing [bool] (default: false)
 # doubleStep: enable pawn double step [bool] (default: true)
 # doubleStepRank: relative rank from where pawn double steps are allowed [Rank] (default: 2)
 # doubleStepRankMin: earlist relative rank from where pawn double steps are allowed [Rank] (default: 2)

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -157,6 +157,7 @@
 # mandatoryPiecePromotion: piece promotion (and demotion if enabled) is mandatory [bool] (default: false)
 # pieceDemotion: enable demotion of pieces (e.g., Kyoto shogi) [bool] (default: false)
 # blastOnCapture: captures explode all adjacent non-pawn pieces (e.g., atomic chess) [bool] (default: false)
+# petrifyOnCapture: captures replace the capturing piece by a wall square [bool] (default: false)
 # doubleStep: enable pawn double step [bool] (default: true)
 # doubleStepRank: relative rank from where pawn double steps are allowed [Rank] (default: 2)
 # doubleStepRankMin: earlist relative rank from where pawn double steps are allowed [Rank] (default: 2)

--- a/tests/perft.sh
+++ b/tests/perft.sh
@@ -145,6 +145,7 @@ if [[ $1 == "all" ||  $1 == "largeboard" ]]; then
   expect perft.exp opulent startpos 3 133829 > /dev/null
   expect perft.exp tencubed startpos 3 68230 > /dev/null
   expect perft.exp centaur startpos 3 24490 > /dev/null
+  expect perft.exp gustav3 startpos 4 331659 > /dev/null
   expect perft.exp shako "fen 4kc3c/ernbq1b1re/ppp3p1pp/3p2pp2/4p5/5P4/2PN2P3/PP1PP2PPP/ER1BQKBNR1/5C3C w KQ - 0 9" 3 26325 > /dev/null
   expect perft.exp shako "fen 4ncr1k1/1cr2P4/pp2p2pp1/P7PN/2Ep1p4/B3P1eN2/2P1n1P3/1B1P1K4/9p/5C2CR w - - 0 1" 3 180467 > /dev/null
   expect perft.exp shako "fen r5k3/4q2c2/1ebppnp3/1pp3BeEQ/10/2PE2P3/1P3P4/5NP2P/rR3KB3/7C2 w Q - 3 35" 2 4940 > /dev/null
@@ -163,6 +164,7 @@ fi
 
 # special variants
 if [[ $1 == "all" ]]; then
+  expect perft.exp duck startpos 1 640 > /dev/null
   expect perft.exp amazons startpos 1 2176 > /dev/null
 fi
 

--- a/tests/perft.sh
+++ b/tests/perft.sh
@@ -146,6 +146,7 @@ if [[ $1 == "all" ||  $1 == "largeboard" ]]; then
   expect perft.exp tencubed startpos 3 68230 > /dev/null
   expect perft.exp centaur startpos 3 24490 > /dev/null
   expect perft.exp gustav3 startpos 4 331659 > /dev/null
+  expect perft.exp omicron startpos 4 967381 > /dev/null
   expect perft.exp shako "fen 4kc3c/ernbq1b1re/ppp3p1pp/3p2pp2/4p5/5P4/2PN2P3/PP1PP2PPP/ER1BQKBNR1/5C3C w KQ - 0 9" 3 26325 > /dev/null
   expect perft.exp shako "fen 4ncr1k1/1cr2P4/pp2p2pp1/P7PN/2Ep1p4/B3P1eN2/2P1n1P3/1B1P1K4/9p/5C2CR w - - 0 1" 3 180467 > /dev/null
   expect perft.exp shako "fen r5k3/4q2c2/1ebppnp3/1pp3BeEQ/10/2PE2P3/1P3P4/5NP2P/rR3KB3/7C2 w Q - 3 35" 2 4940 > /dev/null


### PR DESCRIPTION
Add support for squares that are neither accessible nor traversible, using the standard `*` notation.

* Add support for duck chess, closing #528.
* Add support for wall squares, e.g., Gustav III chess, closing #53.
* Refactor game of the amazons to use wall squares.
  * This changes both the FEN and move representation.
* Enable -DALLVARS for both pyffish and ffishjs.

Note: With this commit `pieces() == pieces(WHITE) | pieces(BLACK)` can no longer be assumed due to the possibility of wall squares.