### PR TITLE
Added promotion duty to Mansindam

### DIFF
--- a/src/variants.ini
+++ b/src/variants.ini
@@ -791,4 +791,5 @@ flagPiece = k
 whiteFlag = *9
 blackFlag = *1
 immobilityIllegal = true
+mandatoryPiecePromotion = true
 


### PR DESCRIPTION
'mandatoryPiecePromotion = true'

Added this.

In fact, it doesn't affect the game even if it exists, but I thought it would be better to have it, so I added it.