### PR TITLE
Added the Benedict Morph variant

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1580,7 +1580,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
       captured = NO_PIECE;
   }
   st->capturedpromoted = is_promoted(to);
-  st->unpromotedCapturedPiece = captured ? unpromoted_piece_on(to) : NO_PIECE;
+  st->unpromotedCapturedPiece = captured ? unpromoted_piece_on(to) : NO_PIsECE;
   st->pass = is_pass(m);
 
   assert(color_of(pc) == us);
@@ -1931,11 +1931,61 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
       assert(type_of(pc) != PAWN);
       st->epSquares = between_bb(from, to) & var->enPassantRegion[them];
       for (Bitboard b = st->epSquares; b; )
-          k ^= Zobrist::enpassant[file_of(pop_lsb(b))];
+        k ^= Zobrist::enpassant[file_of(pop_lsb(b))];
   }
 
   // Set capture piece
   st->capturedPiece = captured;
+
+  // Benedict Morph
+  if (var->captureMorph
+      && captured != NO_PIECE
+      && type_of(m) != DROP
+      && !is_pass(m))
+  {
+      Piece cur = piece_on(to);
+      if (!(var->rexExclusiveMorph && type_of(cur) == KING)){
+          PieceType targetType = type_of(captured);
+
+          // If it captures the same type of piece, nothing to do
+          if (type_of(cur) != targetType) 
+          {
+              // Record for undo
+              st->didMorph   = true;
+              st->morphedFrom = cur;
+              st->morphedTo   = make_piece(us, targetType);
+              st->morphSquare = to;
+  
+              // Replace piece type on the board
+              remove_piece(to);
+              put_piece(st->morphedTo, to);
+  
+              if (Eval::useNNUE) {
+                  bool patched = false;
+            
+                  // Patch the mover's existing "to" entry so NNUE sees only the final identity
+                  for (int i = 0; i < dp.dirty_num; ++i) {
+                      if (dp.to[i] == to) {
+                          dp.piece[i] = st->morphedTo;   // Overwrite with final (morphed) piece
+                          patched = true;
+                          break;
+                      }
+                  }
+          
+                  // If no "to" entry exists, append a replacement-in-place
+                  if (!patched) {
+                      dp.piece[dp.dirty_num]     = st->morphedTo;
+                      dp.handPiece[dp.dirty_num] = NO_PIECE;
+                      dp.from[dp.dirty_num]      = SQ_NONE;
+                      dp.to[dp.dirty_num]        = to;
+                      dp.dirty_num++;
+                  }
+              }
+          } 
+      }
+  } else {
+      st->didMorph = false;
+  }
 
   // Add gating piece
   if (is_gating(m))
@@ -2148,6 +2198,19 @@ void Position::undo_move(Move m) {
          || (type_of(m) == PROMOTION && sittuyin_promotion())
          || (is_pass(m) && (pass(us) || var->wallOrMove)));
   assert(type_of(st->capturedPiece) != KING);
+  
+  if (st->didMorph && st->morphSquare == to)
+  {
+    // Replace morphed piece back to original type at 'to'
+    remove_piece(to);
+    put_piece(st->morphedFrom, to);
+
+    // Update 'pc' to the pre-morph piece so the rest of undo logic sees the right type.
+    pc = st->morphedFrom;
+
+    // Clear flag
+    st->didMorph = false;
+  }
 
   // Reset wall squares
   byTypeBB[ALL_PIECES] ^= st->wallSquares ^ st->previous->wallSquares;

--- a/src/position.h
+++ b/src/position.h
@@ -83,6 +83,10 @@ struct StateInfo {
   bool       pass;
   Move       move;
   int        repetition;
+  bool       didMorph;
+  Piece      morphedFrom;
+  Piece      morphedTo;
+  Square     morphSquare;
 
   // Used by NNUE
   Eval::NNUE::Accumulator accumulator;

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -1228,6 +1228,18 @@ namespace {
         v->flyingGeneral = true;
         return v;
     }
+
+    // Benedict Morph
+    // Capturing piece morphs into the type of the captured piece
+    // Promotions on capturing moves are overridden by this morph
+    // King captures as usual
+    Variant* benedictmorph_variant() {
+        Variant* v = chess_variant_base()->init();
+        v->nnueAlias = "benedictmorph";
+        v->captureMorph = true;
+        v->rexExclusiveMorph = true;
+        return v;
+}
 #ifdef LARGEBOARDS
     // Shogi (Japanese chess)
     // https://en.wikipedia.org/wiki/Shogi
@@ -1915,6 +1927,7 @@ void VariantMap::init() {
     add("flipello", flipello_variant());
     add("minixiangqi", minixiangqi_variant());
     add("raazuvaa", raazuvaa_variant());
+    add("benedictmorph", benedictmorph_variant());
 #ifdef LARGEBOARDS
     add("shogi", shogi_variant());
     add("checkshogi", checkshogi_variant());

--- a/src/variant.h
+++ b/src/variant.h
@@ -64,6 +64,8 @@ struct Variant {
   bool mandatoryPiecePromotion = false;
   bool pieceDemotion = false;
   bool blastOnCapture = false;
+  bool captureMorph = false;
+  bool rexExclusiveMorph = false;
   PieceSet blastImmuneTypes = NO_PIECE_SET;
   PieceSet mutuallyImmuneTypes = NO_PIECE_SET;
   PieceSet petrifyOnCaptureTypes = NO_PIECE_SET;


### PR DESCRIPTION
Implements the "Benedict Morph" chess variant; a morph-on-capture rule inspired by the original Benedict game, but simplified for clarity and engine compatibility.

Rules summary
----------------
- When a piece captures an opponent's piece, it *morphs* into the type of the captured piece (keeping its original color).
    • Example: a white bishop capturing a black knight becomes a white knight on the destination square.
- The captured piece is removed as usual.
- All other rules of orthodox chess apply (castling, en passant, promotions, check/mate conditions, etc.).
- The king is **rex-exclusive**:
    • The king can capture, but never morphs, it always remains a king.

Implementation details
-------------------------
- Added new variant factory `benedictmorph_variant()` in variant.cpp.
- Added four fields in `StateInfo` to record morph data: `didMorph`, `morphedFrom`, `morphedTo`, `morphSquare`.
- Modified `Position::do_move()`:
    • Detect capture and perform morph before gating.
    • Skip morph if the mover is a king (rex-exclusive).
    • Update NNUE dirtyPiece list to reflect the final piece identity.
- Modified `Position::undo_move()` to reverse the morph.

Rex-exclusive by default. Future extensions could include a non-rex-exclusive mode or a "no king captures" variant.